### PR TITLE
Fix buildroot slirp by moving to freedesktop.org one

### DIFF
--- a/package/slirp/001-fix-meson-version.patch
+++ b/package/slirp/001-fix-meson-version.patch
@@ -1,0 +1,10 @@
+--- a/meson.build	2020-08-16 13:01:58.328656356 +0200
++++ b/meson.build	2020-08-16 12:59:29.337736875 +0200
+@@ -3,6 +3,7 @@
+   license : 'BSD-3-Clause',
+   default_options : ['warning_level=1', 'c_std=gnu99'],
+   meson_version : '>= 0.49',
++  version : '4.3.1'
+ )
+ 
+ meson.add_dist_script('build-aux/meson-dist', meson.project_version(), meson.source_root())

--- a/package/slirp/slirp.mk
+++ b/package/slirp/slirp.mk
@@ -4,11 +4,16 @@
 #
 ################################################################################
 
+# batocera
+SLIRP_VERSION = v4.3.1
+SLIRP_SITE = https://gitlab.freedesktop.org/slirp/libslirp/-/archive/$(SLIRP_VERSION)
+SLIRP_SOURCE = libslirp-$(SLIRP_VERSION).tar.gz
 # There's no tarball releases of slirp, so we use the git repo
 # Also, there's no tag, so we use a random SHA1 (master's HEAD
 # of today)
-SLIRP_VERSION = 8c2da74c1385242f20799fec8c04f8378edc6550
-SLIRP_SITE = git://anongit.freedesktop.org/spice/slirp
+#SLIRP_VERSION = 8c2da74c1385242f20799fec8c04f8378edc6550
+#SLIRP_SITE = git://anongit.freedesktop.org/spice/slirp
+
 SLIRP_LICENSE = BSD-4-Clause, BSD-2-Clause
 # Note: The license file 'COPYRIGHT' is missing from the sources,
 # although some files refer to it.
@@ -16,6 +21,9 @@ SLIRP_INSTALL_STAGING = YES
 
 # As we're using the git tree, there's no ./configure,
 # so we need to autoreconf.
-SLIRP_AUTORECONF = YES
+#batocera
+#SLIRP_AUTORECONF = YES
 
-$(eval $(autotools-package))
+#batocera
+#$(eval $(autotools-package))
+$(eval $(meson-package))


### PR DESCRIPTION
This package is not used in batocera except melonDS.
This package is only used in BR as QEMU dependency.
So it's safe to upgrade.
