### PR TITLE
package/strace: disable mpers support

### DIFF
--- a/package/strace/strace.mk
+++ b/package/strace/strace.mk
@@ -9,15 +9,7 @@ STRACE_SOURCE = strace-$(STRACE_VERSION).tar.xz
 STRACE_SITE = https://strace.io/files/$(STRACE_VERSION)
 STRACE_LICENSE = LGPL-2.1+
 STRACE_LICENSE_FILES = COPYING LGPL-2.1-or-later
-STRACE_CONF_OPTS = --enable-mpers=check
-
-# strace bundle some kernel headers to build libmpers, this mixes userspace
-# headers and kernel headers which break the build with musl.
-# The stddef.h from gcc is used instead of the one from musl.
-ifeq ($(BR2_TOOLCHAIN_USES_MUSL),y)
-STRACE_CONF_OPTS += st_cv_m32_mpers=no \
-	st_cv_mx32_mpers=no
-endif
+STRACE_CONF_OPTS = --enable-mpers=no
 
 ifeq ($(BR2_PACKAGE_LIBUNWIND),y)
 STRACE_DEPENDENCIES += libunwind


### PR DESCRIPTION
On aarch64 With the config option "--enable-mpers=check" the configure.ac
script searchs for a 32bit compiler. When a matching compiler is found
in the PATH some compatiblity checks are done. This can fail when the
available kernel headers on host and buildroot target does not match.

Since buildroot does not support 32bit binaries when building for 64bit
architecture (no -m32 option) we can disable this option unconditionally.

When disabling unconditionally also the configuration for toolchain using
MUSL can be removed.

Cc: Baruch Siach <baruch@tkos.co.il>
Cc: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
Cc: Brandon Maier <brandon.maier@rockwellcollins.com>
Signed-off-by: Heiko Thiery <heiko.thiery@gmail.com>
Signed-off-by: Yann E. MORIN <yann.morin.1998@free.fr>