### PR TITLE
S50dropbear: Fix bashism

### DIFF
--- a/package/dropbear/S50dropbear
+++ b/package/dropbear/S50dropbear
@@ -11,7 +11,7 @@ systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoce
 start() {
         # batocera
         enabled="`$systemsetting  -command load -key system.ssh.enabled`"
-        if [ "$enabled" == "0" ];then
+        if [ "$enabled" = "0" ]; then
           echo "SSH services: disabled"
           exit 0
         fi


### PR DESCRIPTION
`==` is a bashism, it should be `=` for POSIX shell compatibility