### PR TITLE
Migrate to the new batocera-settings-(get|set)

### DIFF
--- a/package/dropbear/S50dropbear
+++ b/package/dropbear/S50dropbear
@@ -8,7 +8,7 @@ test -r /etc/default/dropbear && . /etc/default/dropbear
 
 start() {
         # batocera
-        enabled="`/usr/bin/batocera-settings -r system.ssh.enabled`"
+        enabled="$(/usr/bin/batocera-settings-get system.ssh.enabled)"
         if [ "$enabled" = "0" ]; then
           echo "SSH services: disabled"
           exit 0


### PR DESCRIPTION
Migrates all callers to the new settings binaries.

Companion PR: https://github.com/batocera-linux/batocera.linux/pull/2681

* [x] Requires https://github.com/batocera-linux/batocera.linux/pull/2680 to be merged first