### PR TITLE
package/solarus: Fix OpenGLES2 build

### DIFF
--- a/package/solarus/0001-Add-a-basic-FindOpenGLES2.cmake.patch
+++ b/package/solarus/0001-Add-a-basic-FindOpenGLES2.cmake.patch
@@ -1,0 +1,48 @@
+From 2bf0e98f17d92fd86ee61be179e3cebe93f75ea7 Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Sun, 3 Jan 2021 12:38:13 +0000
+Subject: [PATCH] Add a basic FindOpenGLES2.cmake
+
+Fixes #1324
+---
+ cmake/modules/FindOpenGLES2.cmake | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+ create mode 100644 cmake/modules/FindOpenGLES2.cmake
+
+diff --git a/cmake/modules/FindOpenGLES2.cmake b/cmake/modules/FindOpenGLES2.cmake
+new file mode 100644
+index 000000000..70fd5e6f0
+--- /dev/null
++++ b/cmake/modules/FindOpenGLES2.cmake
+@@ -0,0 +1,28 @@
++# Try to find OpenGLES2. Once done this will define:
++#     OPENGLES2_FOUND
++#     OPENGLES2_INCLUDE_DIRS
++#     OPENGLES2_LIBRARIES
++#     OPENGLES2_DEFINITIONS
++
++find_package(PkgConfig QUIET)
++
++pkg_check_modules(PC_OPENGLES2 glesv2)
++
++if (PC_OPENGLES2_FOUND)
++    set(OPENGLES2_DEFINITIONS ${PC_OPENGLES2_CFLAGS_OTHER})
++endif ()
++
++find_path(OPENGLES2_INCLUDE_DIRS NAMES GLES2/gl2.h
++    HINTS ${PC_OPENGLES2_INCLUDEDIR} ${PC_OPENGLES2_INCLUDE_DIRS}
++)
++
++set(OPENGLES2_NAMES ${OPENGLES2_NAMES} glesv2 GLESv2)
++find_library(OPENGLES2_LIBRARIES NAMES ${OPENGLES2_NAMES}
++    HINTS ${PC_OPENGLES2_LIBDIR} ${PC_OPENGLES2_LIBRARY_DIRS}
++)
++
++include(FindPackageHandleStandardArgs)
++find_package_handle_standard_args(OpenGLES2 REQUIRED_VARS OPENGLES2_INCLUDE_DIRS OPENGLES2_LIBRARIES
++                                  FOUND_VAR OPENGLES2_FOUND)
++
++mark_as_advanced(OPENGLES2_INCLUDE_DIRS OPENGLES2_LIBRARIES)
+-- 
+2.27.0
+

--- a/package/solarus/solarus.mk
+++ b/package/solarus/solarus.mk
@@ -16,13 +16,21 @@ SOLARUS_LICENSE_FILES = license.txt
 # Install libsolarus.so
 SOLARUS_INSTALL_STAGING = YES
 
-SOLARUS_DEPENDENCIES = glm libgl libmodplug libogg libvorbis openal physfs \
+SOLARUS_DEPENDENCIES = glm libmodplug libogg libvorbis openal physfs \
 	sdl2 sdl2_image sdl2_ttf
 
 # Disable launcher GUI (requires Qt5)
 SOLARUS_CONF_OPTS = \
 	-DSOLARUS_GUI=OFF \
 	-DSOLARUS_TESTS=OFF
+
+ifeq ($(BR2_PACKAGE_HAS_LIBGL),y)
+SOLARUS_DEPENDENCIES += libgl
+else
+ifeq ($(BR2_PACKAGE_HAS_LIBGLES),y)
+SOLARUS_DEPENDENCIES += libgles
+endif
+endif
 
 ifeq ($(BR2_PACKAGE_LUAJIT),y)
 SOLARUS_CONF_OPTS += -DSOLARUS_USE_LUAJIT=ON


### PR DESCRIPTION
1. Adds a patch that fixes OpenGLES2 build
   https://gitlab.com/solarus-games/solarus/-/merge_requests/1364

2. Updates Config.in and solarus.mk to support OpenGLES2

Also sent a patch upstream https://patchwork.ozlabs.org/project/buildroot/patch/20210103125927.1045995-1-glex.spb@gmail.com/

/cc @rtissera 