### PR TITLE
rpi4: libcec

### DIFF
--- a/package/libcec/libcec.mk
+++ b/package/libcec/libcec.mk
@@ -36,6 +36,13 @@ LIBCEC_CONF_OPTS += \
 	-DCMAKE_CXX_FLAGS="$(TARGET_CXXFLAGS) \
 		-I$(STAGING_DIR)/usr/include/interface/vmcs_host/linux \
 		-I$(STAGING_DIR)/usr/include/interface/vcos/pthreads"
+endif 
+
+# batocera
+ifeq ($(BR2_PACKAGE_BATOCERA_RPI_MESA3D),y)
+LIBCEC_CONF_OPTS += \
+	-DHAVE_RPI_API=0 \
+	-DHAVE_LINUX_API=1
 endif
 
 ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_ROCKCHIP_ANY),y)


### PR DESCRIPTION
libcec with api-rpi does not work in kms activating api-linux for rpi4 (rpi-mesa3d)
