### PR TITLE
Bump PW

### DIFF
--- a/package/pipewire/pipewire.hash
+++ b/package/pipewire/pipewire.hash
@@ -1,4 +1,4 @@
 # Locally calculated
-sha256  8b2af6138529fd9214dd148f2a6304f13c16e0b0d3a4a98c1afa87b7e65c574f  pipewire-0.3.32.tar.gz
+sha256  8b2af6138529fd9214dd148f2a6304f13c16e0b0d3a4a98c1afa87b7e65c574f  pipewire-0.3.33.tar.gz
 sha256  8909c319a7e27dbb33a15b9035f89ab3b7b2f6a12f8bcddc755206a8db1ada44  COPYING
 sha256  7db6138b0385e260ae8f09f050ea66c4e4fe775a11060d7f6ca2beb47f192d6f  LICENSE

--- a/package/pipewire/pipewire.mk
+++ b/package/pipewire/pipewire.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PIPEWIRE_VERSION = 0.3.32
+PIPEWIRE_VERSION = 0.3.33
 PIPEWIRE_SITE = $(call github,PipeWire,pipewire,$(PIPEWIRE_VERSION))
 PIPEWIRE_LICENSE = MIT
 PIPEWIRE_LICENSE_FILES = COPYING LICENSE


### PR DESCRIPTION
Good features is now pw-top show BT devices correctly.
Other good point : 
https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1443 
https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/842 (merged)
And some fixes