### PR TITLE
Added '--no-same-owner' to B2R_TAR_OPTIONS

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -159,7 +159,7 @@ config BR2_LZCAT
 
 config BR2_TAR_OPTIONS
 	string "Tar options"
-	default ""
+	default "--no-same-owner"
 	help
 	  Options to pass to tar when extracting the sources.
 	  E.g. " -v --exclude='*.svn*'" to exclude all .svn internal


### PR DESCRIPTION
Preventing compiling errors issued by "un"-TAR permission restrictions when using unprivileged containers to compile (e.g. Ubuntu 20.04 as a "Proxmox" container).
FYI: This will not affect negatively compiling on a non-container system (e.g. bare metal or VM).