### PR TITLE
simplify gdb build

### DIFF
--- a/package/gdb/gdb.mk
+++ b/package/gdb/gdb.mk
@@ -5,6 +5,13 @@
 ################################################################################
 
 GDB_VERSION = $(call qstrip,$(BR2_GDB_VERSION))
+
+ifeq ($(GDB_VERSION),)
+GDB_VERSION = 10.2
+BR2_PACKAGE_GDB_DEBUGGER = y
+BR2_PACKAGE_GDB_SERVER = y
+endif # GDB_VERSION
+
 GDB_SITE = $(BR2_GNU_MIRROR)/gdb
 GDB_SOURCE = gdb-$(GDB_VERSION).tar.xz
 


### PR DESCRIPTION
GDB can be built by simple command like:
````
make x86_64-pkg PKG=gdb
````
or
````
make rk3326-pkg PKG=gdb
````

GDB still is **not** included in default build (this pull request doesn't affect default build, but it allows to quickly build gdb if needed).
As the adjacent lines lines haven't been changed for 7-9 years, this shouldn't cause merging issues when updating buildroot.