### PR TITLE
fix: update pcre and pcre2 to target new repo

### DIFF
--- a/package/pcre/pcre.mk
+++ b/package/pcre/pcre.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 PCRE_VERSION = 8.44
-PCRE_SITE = https://ftp.pcre.org/pub/pcre
+PCRE_SITE = http://downloads.sourceforge.net/project/pcre/pcre/$(PCRE_VERSION)
 PCRE_SOURCE = pcre-$(PCRE_VERSION).tar.bz2
 PCRE_LICENSE = BSD-3-Clause
 PCRE_LICENSE_FILES = LICENCE

--- a/package/pcre2/pcre2.mk
+++ b/package/pcre2/pcre2.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 PCRE2_VERSION = 10.37
-PCRE2_SITE = https://ftp.pcre.org/pub/pcre
+PCRE2_SITE = http://downloads.sourceforge.net/project/pcre/pcre2/$(PCRE_VERSION)
 PCRE2_SOURCE = pcre2-$(PCRE2_VERSION).tar.bz2
 PCRE2_LICENSE = BSD-3-Clause
 PCRE2_LICENSE_FILES = LICENCE

--- a/package/pcre2/pcre2.mk
+++ b/package/pcre2/pcre2.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 PCRE2_VERSION = 10.37
-PCRE2_SITE = http://downloads.sourceforge.net/project/pcre/pcre2/$(PCRE_VERSION)
+PCRE2_SITE = http://downloads.sourceforge.net/project/pcre/pcre2/$(PCRE2_VERSION)
 PCRE2_SOURCE = pcre2-$(PCRE2_VERSION).tar.bz2
 PCRE2_LICENSE = BSD-3-Clause
 PCRE2_LICENSE_FILES = LICENCE


### PR DESCRIPTION
the repo `https://ftp.pcre.org/pub/pcre` don't work anymore.
We need to use `http://downloads.sourceforge.net/project/pcre/pcre/` instead of `https://ftp.pcre.org/pub/pcre`