### PR TITLE
Bump ZSTD

### DIFF
--- a/package/zstd/zstd.hash
+++ b/package/zstd/zstd.hash
@@ -1,5 +1,5 @@
-# From https://github.com/facebook/zstd/releases/download/v1.5.0/zstd-1.5.0.tar.gz.sha256
-sha256  5194fbfa781fcf45b98c5e849651aa7b3b0a008c6b72d4a0db760f3002291e94  zstd-1.5.0.tar.gz
+# From https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz.sha256
+sha256  7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0  zstd-1.5.2.tar.gz
 
 # License files (locally computed)
 sha256  2c1a7fa704df8f3a606f6fc010b8b5aaebf403f3aeec339a12048f1ba7331a0b  LICENSE

--- a/package/zstd/zstd.mk
+++ b/package/zstd/zstd.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-ZSTD_VERSION = 1.5.0
+ZSTD_VERSION = 1.5.2
 ZSTD_SITE = https://github.com/facebook/zstd/releases/download/v$(ZSTD_VERSION)
 ZSTD_INSTALL_STAGING = YES
 ZSTD_LICENSE = BSD-3-Clause or GPL-2.0


### PR DESCRIPTION
Build OK

Compiler | Scenario | v1.5.0 Speed | v1.5.1 Speed | Delta
-- | -- | -- | -- | --
gcc-11 | Literal compression - 128KB block | 748 MB/s | 927 MB/s | +23.9%
clang-13 | Literal compression - 128KB block | 810 MB/s | 927 MB/s | +14.4%
gcc-11 | Literal compression - 4KB block | 223 MB/s | 321 MB/s | +44.0%
clang-13 | Literal compression - 4KB block | 224 MB/s | 310 MB/s | +38.2%
gcc-11 | Literal decompression - 128KB block | 1164 MB/s | 1500 MB/s | +28.8%
clang-13 | Literal decompression - 128KB block | 1006 MB/s | 1504 MB/s | +49.5%

Version | gcc-11 size | clang-13 size
-- | -- | --
v1.5.1 | 1177 KB | 1167 KB
v1.5.0 | 1338 KB | 1460 KB
v1.4.9 | 1137 KB | 1151 KB


