### PR TITLE
[WIP] package/python-adafruit-circuitpython-ws2801: new package

### DIFF
--- a/DEVELOPERS
+++ b/DEVELOPERS
@@ -2390,6 +2390,9 @@ F:	package/ripgrep/
 N:	Santosh Multhalli <santosh.multhalli@collins.com>
 F:	package/valijson/
 
+N:	Scott Shawcroft <scott@chickadee.tech>
+F:	package/python-adafruit-circuitpython-ws2801/
+
 N:	Sébastien Szymanski <sebastien.szymanski@armadeus.com>
 F:	package/mmc-utils/
 F:	package/python-flask-jsonrpc/

--- a/package/Config.in
+++ b/package/Config.in
@@ -879,6 +879,7 @@ endif
 	source "package/python3/Config.in"
 if BR2_PACKAGE_PYTHON || BR2_PACKAGE_PYTHON3
 menu "External python modules"
+	source "package/python-adafruit-circuitpython-ws2801/Config.in"
 	source "package/python-aenum/Config.in"
 	source "package/python-aioblescan/Config.in"
 	source "package/python-aiocoap/Config.in"

--- a/package/python-adafruit-circuitpython-ws2801/Config.in
+++ b/package/python-adafruit-circuitpython-ws2801/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_PYTHON_ADAFRUIT_CIRCUITPYTHON_WS2801
+	bool "python-adafruit-circuitpython-ws2801"
+	help
+	  CircuitPython library for WS2801 LEDs.
+
+	  https://pypi.org/project/adafruit-circuitpython-ws2801

--- a/package/python-adafruit-circuitpython-ws2801/python-adafruit-circuitpython-ws2801.hash
+++ b/package/python-adafruit-circuitpython-ws2801/python-adafruit-circuitpython-ws2801.hash
@@ -1,0 +1,8 @@
+# md5, sha256 from https://pypi.org/pypi/adafruit-circuitpython-ws2801/json
+md5  ea607a3efb572b4c5c75787f1ba1de3f  adafruit-circuitpython-ws2801-0.10.9.tar.gz
+sha256  dbd48d8569d60bcb4960ef7cfbbd75bfb289190f8e5078e8f810e194974c0ef4  adafruit-circuitpython-ws2801-0.10.9.tar.gz
+# Locally computed sha256 checksums
+sha256  900834fa8ecdc2bd06abe78299f1495f407f1462849fc70993bccad593cdb89f  LICENSE
+sha256  b89aeb7c2a164a0576786dd2a8b57f2fb628b23981f0a06bd77e2f99a9befa0f  LICENSES/CC-BY-4.0.txt
+sha256  8f25018489d6fe0dec34a352314c38dc146247b7de65735790f4398a92afa84b  LICENSES/MIT.txt
+sha256  567675401b124cc8ed1095665474a4f04ce1ed44134ee7eec46a691e387a1397  LICENSES/Unlicense.txt

--- a/package/python-adafruit-circuitpython-ws2801/python-adafruit-circuitpython-ws2801.mk
+++ b/package/python-adafruit-circuitpython-ws2801/python-adafruit-circuitpython-ws2801.mk
@@ -1,0 +1,14 @@
+################################################################################
+#
+# python-adafruit-circuitpython-ws2801
+#
+################################################################################
+
+PYTHON_ADAFRUIT_CIRCUITPYTHON_WS2801_VERSION = 0.10.9
+PYTHON_ADAFRUIT_CIRCUITPYTHON_WS2801_SOURCE = adafruit-circuitpython-ws2801-$(PYTHON_ADAFRUIT_CIRCUITPYTHON_WS2801_VERSION).tar.gz
+PYTHON_ADAFRUIT_CIRCUITPYTHON_WS2801_SITE = https://files.pythonhosted.org/packages/49/3b/3ed4b50050843c6b6fdc97a7ab9afdafe114e980307c4851f66b53e21c13
+PYTHON_ADAFRUIT_CIRCUITPYTHON_WS2801_SETUP_TYPE = setuptools
+PYTHON_ADAFRUIT_CIRCUITPYTHON_WS2801_LICENSE = MIT
+PYTHON_RPI_WS281X_LICENSE_FILES = LICENSE LICENSES/CC-BY-4.0.txt LICENSES/MIT.txt LICENSES/Unlicense.txt
+
+$(eval $(python-package))


### PR DESCRIPTION
CircuitPython library for WS2801 LEDs.

WORK IN PROGRES: Please do not merge yet