### PR TITLE
bump firmware & fix wifi

### DIFF
--- a/package/rpi-firmware/rpi-firmware.hash
+++ b/package/rpi-firmware/rpi-firmware.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  efa43d04a3813fc2ecdea1f7013c6869afa523b59ae063b30eb78e3faac2fd63  rpi-firmware-7cb1aa0ff575959163e1cea042e5e3ab5a7a90d2.tar.gz
+sha256  d53c8b6cef1776f558ff31a004541eede1eb5333cab9c06bfd0f353d2e26d2ac  rpi-firmware-7aae0a906cc980ba4ccd3d3031a2a632d757e51a.tar.gz
 sha256  c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b  boot/LICENCE.broadcom

--- a/package/rpi-firmware/rpi-firmware.mk
+++ b/package/rpi-firmware/rpi-firmware.mk
@@ -3,8 +3,8 @@
 # rpi-firmware
 #
 ################################################################################
-# batocera (update) - Aligns to kernel version: 5.15.28
-RPI_FIRMWARE_VERSION = 7cb1aa0ff575959163e1cea042e5e3ab5a7a90d2
+# batocera (update) - Aligns to kernel version: 5.15.30
+RPI_FIRMWARE_VERSION = 7aae0a906cc980ba4ccd3d3031a2a632d757e51a
 RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))
 RPI_FIRMWARE_LICENSE = BSD-3-Clause
 RPI_FIRMWARE_LICENSE_FILES = boot/LICENCE.broadcom
@@ -48,6 +48,7 @@ define RPI_FIRMWARE_INSTALL_DTB_OVERLAYS
 	$(foreach ovldtb,$(wildcard $(@D)/boot/overlays/*.dtbo), \
 		$(INSTALL) -D -m 0644 $(ovldtb) $(BINARIES_DIR)/rpi-firmware/overlays/$(notdir $(ovldtb))
 	)
+	$(INSTALL) -D -m 0644 $(@D)/boot/overlays/overlay_map.dtb $(BINARIES_DIR)/rpi-firmware/overlays/
 endef
 else
 # Still create the directory, so a genimage.cfg can include it independently of


### PR DESCRIPTION
part of rpi 5.15.30 bump
- align BR overlay change
- fix BR issue where firmware wasn't installed to target (https://bugs.busybox.net/show_bug.cgi?id=14676)
- rest in batocera.linux #5833
