### PR TITLE
pipewire isn't required as a dependency

### DIFF
--- a/package/sdl2/sdl2.mk
+++ b/package/sdl2/sdl2.mk
@@ -75,7 +75,7 @@ SDL2_CONF_OPTS += --disable-hidapi
 # pipewire
 ifeq ($(BR2_PACKAGE_PIPEWIRE),y)
 SDL2_CONF_OPTS += --enable-pipewire
-SDL2_DEPENDENCIES += pipewire
+#SDL2_DEPENDENCIES += pipewire
 endif
 
 ifeq ($(BR2_PACKAGE_HAS_UDEV),y)


### PR DESCRIPTION
we don't need to add the dependency as sdl2 builds with the sdl2 option aok