### PR TITLE
host-gslang: batocera-vulkan

### DIFF
--- a/package/mesa3d/Config.in
+++ b/package/mesa3d/Config.in
@@ -10,7 +10,7 @@ menuconfig BR2_PACKAGE_MESA3D
 	select BR2_PACKAGE_WAYLAND_PROTOCOLS if BR2_PACKAGE_WAYLAND
 	select BR2_PACKAGE_ZLIB
 	select BR2_PACKAGE_PYTHON3              if BR2_PACKAGE_WAYLAND && BR2_PACKAGE_MESA3D_NEEDS_X11 #batocera
-	select BR2_PACKAGE_HOST_GLSLANG         if BR2_PACKAGE_WAYLAND && BR2_PACKAGE_MESA3D_NEEDS_X11 #batocera
+	select BR2_PACKAGE_HOST_GLSLANG         if BR2_PACKAGE_BATOCERA_VULKAN && BR2_PACKAGE_MESA3D_NEEDS_X11 #batocera
 	help
 	  Mesa 3D, an open-source implementation of the OpenGL
 	  specification.


### PR DESCRIPTION
Using wayland as required dependency it installs vulkan on platforms which are not supported
