### PR TITLE
bumps x86 kernel to 5.18.19

### DIFF
--- a/linux/linux.hash
+++ b/linux/linux.hash
@@ -1,5 +1,5 @@
 # From https://www.kernel.org/pub/linux/kernel/v5.x/sha256sums.asc
-sha256  40b74d0942f255da07481710e1083412d06e37e45b8f9d9e34ae856db37b9527  linux-5.18.12.tar.xz
+sha256  dff09b251712fb3b387cb4e0f7b097c0ef3c7b6eb7f94a8c9aee6cc023fc88d5  linux-5.18.19.tar.xz
 sha256  22f67ef6b12ef6c0c0353be4b90b4bf4b9b18b858c16c346fa495b67ec718c99  linux-5.17.7.tar.xz
 sha256  888641634f9e0e38cd0efcfec92ea3c126d381b24a514740d3fe3dc9988fd7ad  linux-5.15.39.tar.xz
 sha256  f5e417b32f89318b6d0a230109a592ffd68997817463dc4692fa49ec7fe42f71  linux-5.10.115.tar.xz


### PR DESCRIPTION
fixes - https://github.com/batocera-linux/batocera.linux/issues/6909