### PR TITLE
Revert "bump: rpi-firmware to 1.20221028 (5.15.74)"

### DIFF
--- a/package/rpi-firmware/rpi-firmware.hash
+++ b/package/rpi-firmware/rpi-firmware.hash
@@ -1,3 +1,3 @@
 # Locally computed
-sha256  b6759e64fc9d7bd386e161970df2da294fe356864a2ade497d67a207d7933f05  rpi-firmware-1.20221104.tar.gz
+sha256  fcfa24ce0ea26c60d1a140d4220cb803269c38235a08e2b004f458d4692cb97f  rpi-firmware-1.20220830.tar.gz
 sha256  c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b  boot/LICENCE.broadcom

--- a/package/rpi-firmware/rpi-firmware.mk
+++ b/package/rpi-firmware/rpi-firmware.mk
@@ -3,8 +3,8 @@
 # rpi-firmware
 #
 ################################################################################
-# batocera (update) - Aligns to kernel version: 5.15.76
-RPI_FIRMWARE_VERSION = 1.20221104
+# batocera (update) - Aligns to kernel version: 5.15.61
+RPI_FIRMWARE_VERSION = 1.20220830
 RPI_FIRMWARE_SITE = $(call github,raspberrypi,firmware,$(RPI_FIRMWARE_VERSION))
 RPI_FIRMWARE_LICENSE = BSD-3-Clause
 RPI_FIRMWARE_LICENSE_FILES = boot/LICENCE.broadcom


### PR DESCRIPTION
This reverts commit 1d9839793f978a9269ff9662f2d1adf329883735.