### PR TITLE
Workaround for util-linux build

### DIFF
--- a/package/util-linux/util-linux.mk
+++ b/package/util-linux/util-linux.mk
@@ -243,6 +243,8 @@ endif
 
 # batocera
 HOST_UTIL_LINUX_CONF_OPTS += --enable-libsmartcols
+# batocera
+UTIL_LINUX_CONF_OPTS += --disable-irqtop # ncurses build issue
 
 # Install libmount Python bindings
 ifeq ($(BR2_PACKAGE_PYTHON3),y)


### PR DESCRIPTION
Skip building irqtop as a workaround for building linux-util command-line tools.
Meant for https://github.com/batocera-linux/batocera.linux/pull/7981