### PR TITLE
Mark dbus-python as pip-compatible package

### DIFF
--- a/package/dbus-python/dbus-python.mk
+++ b/package/dbus-python/dbus-python.mk
@@ -24,6 +24,7 @@ HOST_DBUS_PYTHON_CONF_ENV = \
 	PYTHON_LIBS="`$(HOST_DIR)/bin/python3-config --ldflags`" \
 	PYTHON_EXTRA_LIBS="`$(HOST_DIR)/bin/python3-config --libs --embed`"
 
+# batocera ; #500
 define DBUS_PYTHON_INSTALL_TARGET_CMDS
 	touch $(TARGET_DIR)/usr/lib/python$(PYTHON3_VERSION_MAJOR)/site-packages/dbus_python-$(DBUS_PYTHON_VERSION).egg-info
 endef

--- a/package/dbus-python/dbus-python.mk
+++ b/package/dbus-python/dbus-python.mk
@@ -24,5 +24,9 @@ HOST_DBUS_PYTHON_CONF_ENV = \
 	PYTHON_LIBS="`$(HOST_DIR)/bin/python3-config --ldflags`" \
 	PYTHON_EXTRA_LIBS="`$(HOST_DIR)/bin/python3-config --libs --embed`"
 
+define DBUS_PYTHON_INSTALL_TARGET_CMDS
+	touch $(TARGET_DIR)/usr/lib/python$(PYTHON3_VERSION_MAJOR)/site-packages/dbus_python-$(DBUS_PYTHON_VERSION).egg-info
+endef
+
 $(eval $(autotools-package))
 $(eval $(host-autotools-package))


### PR DESCRIPTION
The PR solves the problem that python packages requiring `dbus-python` cannot be installed.

### Problem
Currently, the package `dbus-python` is available but pip does not know about it:
```
[root@BATOCERA /userdata/system]# pip show dbus-python
WARNING: Package(s) not found: dbus-python
```

When a python package is installed that requires `dbus-python`, pip tries to build it and fails due to the missing build toolchain:
```
[root@BATOCERA /userdata/system]# pip3 install dbus-python
Collecting dbus-python
  Using cached dbus-python-1.3.2.tar.gz (605 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      The Meson build system
      Version: 1.0.0
      Source dir: /tmp/pip-install-ndce0t47/dbus-python_791c0a51cb93420c821b8c91ed901365
      Build dir: /tmp/pip-install-ndce0t47/dbus-python_791c0a51cb93420c821b8c91ed901365/.mesonpy-i34t58o1/build
      Build type: native build
      Project name: dbus-python
      Project version: 1.3.2

      ../../meson.build:4:0: ERROR: Unknown compiler(s): [['cc'], ['gcc'], ['clang'], ['nvc'], ['pgcc'], ['icc'], ['icx']]
 ```
 
### Solution
Creating an empty `egg-info` file is enough for pip to know the package:
```
[root@BATOCERA /userdata/system]# touch /usr/lib/python3.10/site-packages/dbus_python-1.2.18.egg-info
[root@BATOCERA /userdata/system]# pip3 install dbus-python
Requirement already satisfied: dbus-python in /usr/lib/python3.10/site-packages (1.2.18)

[root@BATOCERA /userdata/system]# pip show dbus-python
Name: dbus-python
Version: 1.2.18
Summary:
Home-page:
Author:
Author-email:
License:
Location: /usr/lib/python3.10/site-packages
Requires:
Required-by:
```

### Notes
1. This PR is untested because I have no build environment for buildroot.
2. The `egg-info` seems to be a widely used but legacy format. [PEP-376](https://peps.python.org/pep-0376/) defines a well-standardized `dist-info` structure which may be better suited, but it requires at least 3 files `METADATA`, `RECORD` and `INSTALLER` to be installed and filed correctly. I can't provide these files in the scope of this PR.