### PR TITLE
package/{mesa3d, mesa3d-headers}: bump version to 23.0.1

### DIFF
--- a/package/mesa3d-headers/mesa3d-headers.mk
+++ b/package/mesa3d-headers/mesa3d-headers.mk
@@ -13,7 +13,7 @@ endif
 # Not possible to directly refer to mesa3d variables, because of
 # first/second expansion trickery...
 # When updating the version, please also update mesa3d-headers
-MESA3D_HEADERS_VERSION = 23.0.0
+MESA3D_HEADERS_VERSION = 23.0.1
 MESA3D_HEADERS_SOURCE = mesa-$(MESA3D_HEADERS_VERSION).tar.xz
 MESA3D_HEADERS_SITE = https://archive.mesa3d.org
 MESA3D_HEADERS_DL_SUBDIR = mesa3d

--- a/package/mesa3d/mesa3d.hash
+++ b/package/mesa3d/mesa3d.hash
@@ -1,4 +1,4 @@
-# From
-sha256  01f3cff3763f09e0adabcb8011e4aebc6ad48f6a4dd4bae904fe918707d253e4  mesa-23.0.0.tar.xz
+# From https://gitlab.freedesktop.org/mesa/mesa/-/blob/8797c8a2f6a61e3c3b1926044369bfbfcf1083b1/docs/relnotes/23.0.1.rst
+sha256  e8e586856b55893abae9bdcdb98b41c081d909bb1faf372e6e7262307bf34adf  mesa-23.0.1.tar.xz
 # License
 sha256  a00275a53178e2645fb65be99a785c110513446a5071ff2c698ed260ad917d75  docs/license.rst

--- a/package/mesa3d/mesa3d.mk
+++ b/package/mesa3d/mesa3d.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 # When updating the version, please also update mesa3d-headers
-MESA3D_VERSION = 23.0.0
+MESA3D_VERSION = 23.0.1
 MESA3D_SOURCE = mesa-$(MESA3D_VERSION).tar.xz
 MESA3D_SITE = https://archive.mesa3d.org
 MESA3D_LICENSE = MIT, SGI, Khronos


### PR DESCRIPTION
Release notes: https://gitlab.freedesktop.org/mesa/mesa/-/blob/8797c8a2f6a61e3c3b1926044369bfbfcf1083b1/docs/relnotes/23.0.1.rst