### PR TITLE
package/libcurl: host-autotools-package

### DIFF
--- a/package/libcurl/libcurl.mk
+++ b/package/libcurl/libcurl.mk
@@ -189,3 +189,5 @@ LIBCURL_POST_INSTALL_TARGET_HOOKS += LIBCURL_TARGET_CLEANUP
 endif
 
 $(eval $(autotools-package))
+# batocera - removing host-autotools-package causes dependency problem on pipewire
+$(eval $(host-autotools-package))


### PR DESCRIPTION
removing host-autotools-package causes dependency problem on pipewire