### PR TITLE
package/libcurl: host-libcurl

### DIFF
--- a/package/libcurl/libcurl.mk
+++ b/package/libcurl/libcurl.mk
@@ -188,6 +188,18 @@ endef
 LIBCURL_POST_INSTALL_TARGET_HOOKS += LIBCURL_TARGET_CLEANUP
 endif
 
+# batocera - removing host-libcurl causes dependency problem on pipewire
+HOST_LIBCURL_DEPENDENCIES = host-openssl
+HOST_LIBCURL_CONF_OPTS = \
+	--disable-manual \
+	--disable-ntlm-wb \
+	--disable-curldebug \
+	--with-ssl \
+	--without-gnutls \
+	--without-mbedtls \
+	--without-nss
+
+HOST_LIBCURL_POST_PATCH_HOOKS += LIBCURL_FIX_DOT_PC
+
 $(eval $(autotools-package))
-# batocera - removing host-autotools-package causes dependency problem on pipewire
 $(eval $(host-autotools-package))


### PR DESCRIPTION
removing host-libcurl causes dependency problem on pipewire