### PR TITLE
fix Qt6 base

### DIFF
--- a/package/heimdal/heimdal.mk
+++ b/package/heimdal/heimdal.mk
@@ -9,9 +9,9 @@ HEIMDAL_SITE = https://github.com/heimdal/heimdal/releases/download/heimdal-$(HE
 HOST_HEIMDAL_DEPENDENCIES = host-e2fsprogs host-ncurses host-pkgconf
 HEIMDAL_INSTALL_STAGING = YES
 # static because of -fPIC issues with e2fsprogs on x86_64 host
+# batocera - ignore above, works fine. -fPIC required for Qt6
+# removed --disable-shared & --enable-static options
 HOST_HEIMDAL_CONF_OPTS = \
-	--disable-shared \
-	--enable-static \
 	--without-openldap \
 	--without-capng \
 	--with-db-type-preference= \
@@ -29,6 +29,9 @@ HOST_HEIMDAL_CONF_OPTS = \
 
 # Don't use compile_et from e2fsprogs as it raises a build failure with samba4
 HOST_HEIMDAL_CONF_ENV = ac_cv_prog_COMPILE_ET=no MAKEINFO=true
+# batocera - add the -fPIC flag.
+HOST_HEIMDAL_CONF_ENV += CFLAGS="$(HOST_CFLAGS) -fPIC"
+
 HEIMDAL_LICENSE = BSD-3-Clause
 HEIMDAL_LICENSE_FILES = LICENSE
 HEIMDAL_CPE_ID_VENDOR = heimdal_project

--- a/package/libglvnd/libglvnd.mk
+++ b/package/libglvnd/libglvnd.mk
@@ -9,6 +9,9 @@ LIBGLVND_VERSION = v1.5.0
 LIBGLVND_SOURCE= libglvnd-$(LIBGLVND_VERSION).gz
 LIBGLVND_SITE = https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/$(LIBGLVND_VERSION)
 
+# batocera - host package
+LIBGLVND_DEPENDENCIES = host-libglvnd
+
 LIBGLVND_LICENSE = \
 	libglvnd license, \
 	Apache-2.0 (Khronos headers), \
@@ -52,3 +55,5 @@ LIBGLVND_CONF_OPTS += -Dgles1=false -Dgles2=false
 endif
 
 $(eval $(meson-package))
+# batocera - host package
+$(eval $(host-meson-package))

--- a/package/qt6/qt6base/qt6base.mk
+++ b/package/qt6/qt6base/qt6base.mk
@@ -80,9 +80,7 @@ define QT6BASE_BUILD_CMDS
 	$(TARGET_MAKE_ENV) $(BR2_CMAKE) --build $(QT6BASE_BUILDDIR)
 endef
 
-# batocera - add host directory
 define QT6BASE_INSTALL_STAGING_CMDS
-	$(TARGET_MAKE_ENV) DESTDIR=$(HOST_DIR) $(BR2_CMAKE) --install $(QT6BASE_BUILDDIR)
 	$(TARGET_MAKE_ENV) DESTDIR=$(STAGING_DIR) $(BR2_CMAKE) --install $(QT6BASE_BUILDDIR)
 endef
 
@@ -96,14 +94,15 @@ HOST_QT6BASE_DEPENDENCIES = \
 	host-libb2 \
 	host-pcre2 \
 	host-zlib
+# batocera - gui, testlib & network = ON for other Qt6 packages
 HOST_QT6BASE_CONF_OPTS = \
 	-GNinja \
-	-DFEATURE_gui=OFF \
+	-DFEATURE_gui=ON \
 	-DFEATURE_concurrent=OFF \
 	-DFEATURE_xml=ON \
 	-DFEATURE_sql=OFF \
-	-DFEATURE_testlib=OFF \
-	-DFEATURE_network=OFF \
+	-DFEATURE_testlib=ON \
+	-DFEATURE_network=ON \
 	-DFEATURE_dbus=OFF \
 	-DFEATURE_icu=OFF \
 	-DFEATURE_glib=OFF \


### PR DESCRIPTION
- we need a libOpenGL in host - libglvnd host added
- Heimdal need to be built with -fPIC
- Update Qt6 base as a result for other Qt6 packages