### PR TITLE
revert mesa 23.1 - breaks older amd cards

### DIFF
--- a/package/mesa3d-headers/mesa3d-headers.mk
+++ b/package/mesa3d-headers/mesa3d-headers.mk
@@ -13,7 +13,7 @@ endif
 # Not possible to directly refer to mesa3d variables, because of
 # first/second expansion trickery...
 # When updating the version, please also update mesa3d-headers
-MESA3D_HEADERS_VERSION = 23.1.0
+MESA3D_HEADERS_VERSION = 23.0.3
 MESA3D_HEADERS_SOURCE = mesa-$(MESA3D_HEADERS_VERSION).tar.xz
 MESA3D_HEADERS_SITE = https://archive.mesa3d.org
 MESA3D_HEADERS_DL_SUBDIR = mesa3d

--- a/package/mesa3d/mesa3d.hash
+++ b/package/mesa3d/mesa3d.hash
@@ -1,4 +1,4 @@
-# From https://lists.freedesktop.org/archives/mesa-dev/2023-May/226007.html
-sha256  a9dde3c76571c4806245a05bda1cceee347c3267127e9e549e4f4e225d92e992  mesa-23.1.0.tar.xz
+# From https://gitlab.freedesktop.org/mesa/mesa/-/blob/7c976fbf4a3fca22fd664ba914fd746712ceced7/docs/relnotes/23.0.3.rst
+sha256  386362a5d80df3b096636b67f340e1ce67b705b44767d5bdd11d2ed1037192d5  mesa-23.0.3.tar.xz
 # License
 sha256  a00275a53178e2645fb65be99a785c110513446a5071ff2c698ed260ad917d75  docs/license.rst

--- a/package/mesa3d/mesa3d.mk
+++ b/package/mesa3d/mesa3d.mk
@@ -5,7 +5,7 @@
 ################################################################################
 # batocera (update)
 # When updating the version, please also update mesa3d-headers
-MESA3D_VERSION = 23.1.0
+MESA3D_VERSION = 23.0.3
 MESA3D_SOURCE = mesa-$(MESA3D_VERSION).tar.xz
 MESA3D_SITE = https://archive.mesa3d.org
 MESA3D_LICENSE = MIT, SGI, Khronos


### PR DESCRIPTION
- currently a regression bug is being posted on mesa gitlab
- until 23.1.x fixes this we will stick to 23.0.3 for v37