### PR TITLE
Workaround opus  build on rk3288 

### DIFF
--- a/package/opus/opus.mk
+++ b/package/opus/opus.mk
@@ -40,4 +40,9 @@ ifeq ($(BR2_arm)$(BR2_armeb):$(BR2_ARM_CPU_HAS_ARM),y:)
 OPUS_CONF_OPTS += --disable-asm
 endif
 
+#batocera workaround rk3288 test programs build failure
+ifeq ($(BR2_cortex_a17),y)
+OPUS_CONF_OPTS += --disable-extra-programs
+endif
+
 $(eval $(autotools-package))


### PR DESCRIPTION
For some reason opus 1.3.1 (tested also with opus 1.4, does not resolve issue) does not build test programs properly when targeting Rockchip RK3288 (Cortex A-17 cores).

Workaround for batocera by avoid building "extra programs" from opus package.