### PR TITLE
Add RK3588 hwdec support into ffmpeg (needs patch from batocera side)

### DIFF
--- a/package/ffmpeg/ffmpeg.mk
+++ b/package/ffmpeg/ffmpeg.mk
@@ -521,6 +521,14 @@ else
 FFMPEG_CONF_OPTS += --disable-altivec
 endif
 
+#batocera rk3588 hwdec
+ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_RK3588)$(BR2_PACKAGE_ROCKCHIP_MPP)$(BR2_PACKAGE_ROCKCHIP_RGA),yyy)
+FFMPEG_CONF_OPTS += --enable-rkmpp
+FFMPEG_CONF_OPTS += --enable-version3
+FFMPEG_CONF_OPTS += --enable-librga
+FFMPEG_DEPENDENCIES += rockchip-mpp rockchip-rga
+endif
+
 # Uses __atomic_fetch_add_4
 ifeq ($(BR2_TOOLCHAIN_HAS_LIBATOMIC),y)
 FFMPEG_CONF_OPTS += --extra-libs=-latomic


### PR DESCRIPTION
Rockchip downstream ffmpeg 4.4.1 has hardware decoding support.
Implement required options and dependencies (rkmpp and librga) on buildroot side.
Upcoming patch on batocera.linux repo PR.

This patch is safe because only applies if building RK3588 with Rockchip MPP and RGA libraries enabled.
