### PR TITLE
build `syslinux` installer for host

### DIFF
--- a/boot/syslinux/0021-mtools-build-for-the-host.patch
+++ b/boot/syslinux/0021-mtools-build-for-the-host.patch
@@ -1,0 +1,49 @@
+From cbc07cc8e92d376572cee3c7ac01926925ec7337 Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Thu, 16 Apr 2020 16:56:52 +0200
+Subject: [PATCH] mtools: build for the host
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ mtools/Makefile | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/mtools/Makefile b/mtools/Makefile
+index 70269efd..aa78311d 100755
+--- a/mtools/Makefile
++++ b/mtools/Makefile
+@@ -2,8 +2,8 @@ include $(MAKEDIR)/syslinux.mk
+ 
+ OPTFLAGS = -g -Os
+ INCLUDES = -I$(SRC) -I$(objdir) -I$(SRC)/../libfat -I$(SRC)/../libinstaller
+-CFLAGS	 = $(GCCWARN) -D_FILE_OFFSET_BITS=64 $(OPTFLAGS) $(INCLUDES)
+-LDFLAGS	 = 
++CFLAGS	 = $(CFLAGS_FOR_BUILD) $(GCCWARN) -D_FILE_OFFSET_BITS=64 $(OPTFLAGS) $(INCLUDES)
++LDFLAGS	 = $(LDFLAGS_FOR_BUILD)
+ 
+ SRCS     = syslinux.c \
+ 	   ../libinstaller/fs.c \
+@@ -34,16 +34,16 @@ spotless: clean
+ installer: syslinux
+ 
+ syslinux: $(OBJS)
+-	$(CC) $(LDFLAGS) -o $@ $^
++	$(CC_FOR_BUILD) $(LDFLAGS) -o $@ $^
+ 
+ strip:
+ 	$(STRIP) syslinux
+ 
+ %.o: %.c
+-	$(CC) $(UMAKEDEPS) $(CFLAGS) -c -o $@ $<
++	$(CC_FOR_BUILD) $(UMAKEDEPS) $(CFLAGS) -c -o $@ $<
+ %.i: %.c
+-	$(CC) $(UMAKEDEPS) $(CFLAGS) -E -o $@ $<
++	$(CC_FOR_BUILD) $(UMAKEDEPS) $(CFLAGS) -E -o $@ $<
+ %.s: %.c
+-	$(CC) $(UMAKEDEPS) $(CFLAGS) -S -o $@ $<
++	$(CC_FOR_BUILD) $(UMAKEDEPS) $(CFLAGS) -S -o $@ $<
+ 
+ -include .*.d
+-- 
+2.25.2
+

--- a/boot/syslinux/syslinux.mk
+++ b/boot/syslinux/syslinux.mk
@@ -87,11 +87,12 @@ endef
 # That 'syslinux' binary is an installer actually built for the target.
 # However, buildroot makes no usage of it, so better delete it than have it
 # installed at the wrong place
-define SYSLINUX_POST_INSTALL_CLEANUP
-# batocera need syslinux util
-	# rm -rf $(HOST_DIR)/bin/syslinux
-endef
-SYSLINUX_POST_INSTALL_TARGET_HOOKS += SYSLINUX_POST_INSTALL_CLEANUP
+#
+# batocera: patch added to build syslinux tool for the host
+# define SYSLINUX_POST_INSTALL_CLEANUP
+# 	rm -rf $(HOST_DIR)/bin/syslinux
+# endef
+# SYSLINUX_POST_INSTALL_TARGET_HOOKS += SYSLINUX_POST_INSTALL_CLEANUP
 
 SYSLINUX_IMAGES-$(BR2_TARGET_SYSLINUX_ISOLINUX) += bios/core/isolinux.bin
 SYSLINUX_IMAGES-$(BR2_TARGET_SYSLINUX_PXELINUX) += bios/core/pxelinux.bin


### PR DESCRIPTION
Patch taken from https://bugs.busybox.net/show_bug.cgi?id=13681

The `syslinux` installer is currently compiled for the target system rather than the host system. This works for compiling `x86_64` targets from `x86_64`, but cross-compiles fail in `post-image-script.sh` when it runs the installer. A buildbot contributor put together a patch, but it was never upstreamed. It applies cleanly.

- [X] Compiles
- [X] Tested (macOS Sonoma on M1 compiled, runs on ROG Ally)