### PR TITLE
Fix Wi-Fi for Kernel 4.4 boards

### DIFF
--- a/package/Config.in
+++ b/package/Config.in
@@ -2630,6 +2630,7 @@ endif
 	source "package/wireless_tools/Config.in"
 	source "package/wireshark/Config.in"
 	source "package/wpa_supplicant/Config.in"
+	source "package/wpa_supplicant_k44/Config.in" # batocera
 	source "package/wpan-tools/Config.in"
 	source "package/xinetd/Config.in"
 	source "package/xl2tp/Config.in"

--- a/package/connman/Config.in
+++ b/package/connman/Config.in
@@ -45,8 +45,9 @@ config BR2_PACKAGE_CONNMAN_ETHERNET
 
 config BR2_PACKAGE_CONNMAN_WIFI
 	bool "enable WiFi support"
-	select BR2_PACKAGE_WPA_SUPPLICANT # runtime
-	select BR2_PACKAGE_WPA_SUPPLICANT_DBUS # runtime
+	# batocera
+	depends on BR2_PACKAGE_WPA_SUPPLICANT      || BR2_PACKAGE_WPA_SUPPLICANT_K44      # runtime
+	depends on BR2_PACKAGE_WPA_SUPPLICANT_DBUS || BR2_PACKAGE_WPA_SUPPLICANT_K44_DBUS # runtime
 	help
 	  Enable WiFi support (scan and static/dhcp interface
 	  setup). ConnMan detects the start of wpa_supplicant

--- a/package/wpa_supplicant_k44/0001-2019-7-AP-Silently-ignore-management-frame-from-unexpected-.patch
+++ b/package/wpa_supplicant_k44/0001-2019-7-AP-Silently-ignore-management-frame-from-unexpected-.patch
@@ -16,10 +16,6 @@ where the unexpected response frame from the AP might result in a
 connected station dropping its association.
 
 Signed-off-by: Jouni Malinen <j@w1.fi>
-
-Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
-[Retrieved from:
-https://w1.fi/security/2019-7/0001-AP-Silently-ignore-management-frame-from-unexpected-.patch]
 ---
  src/ap/drv_callbacks.c | 13 +++++++++++++
  src/ap/ieee802_11.c    | 12 ++++++++++++

--- a/package/wpa_supplicant_k44/0001-AP-Silently-ignore-management-frame-from-unexpected-.patch
+++ b/package/wpa_supplicant_k44/0001-AP-Silently-ignore-management-frame-from-unexpected-.patch
@@ -1,0 +1,77 @@
+From 8c07fa9eda13e835f3f968b2e1c9a8be3a851ff9 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Thu, 29 Aug 2019 11:52:04 +0300
+Subject: [PATCH] AP: Silently ignore management frame from unexpected source
+ address
+
+Do not process any received Management frames with unexpected/invalid SA
+so that we do not add any state for unexpected STA addresses or end up
+sending out frames to unexpected destination. This prevents unexpected
+sequences where an unprotected frame might end up causing the AP to send
+out a response to another device and that other device processing the
+unexpected response.
+
+In particular, this prevents some potential denial of service cases
+where the unexpected response frame from the AP might result in a
+connected station dropping its association.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+[Retrieved from:
+https://w1.fi/security/2019-7/0001-AP-Silently-ignore-management-frame-from-unexpected-.patch]
+---
+ src/ap/drv_callbacks.c | 13 +++++++++++++
+ src/ap/ieee802_11.c    | 12 ++++++++++++
+ 2 files changed, 25 insertions(+)
+
+diff --git a/src/ap/drv_callbacks.c b/src/ap/drv_callbacks.c
+index 31587685fe3b..34ca379edc3d 100644
+--- a/src/ap/drv_callbacks.c
++++ b/src/ap/drv_callbacks.c
+@@ -131,6 +131,19 @@ int hostapd_notif_assoc(struct hostapd_data *hapd, const u8 *addr,
+ 			   "hostapd_notif_assoc: Skip event with no address");
+ 		return -1;
+ 	}
++
++	if (is_multicast_ether_addr(addr) ||
++	    is_zero_ether_addr(addr) ||
++	    os_memcmp(addr, hapd->own_addr, ETH_ALEN) == 0) {
++		/* Do not process any frames with unexpected/invalid SA so that
++		 * we do not add any state for unexpected STA addresses or end
++		 * up sending out frames to unexpected destination. */
++		wpa_printf(MSG_DEBUG, "%s: Invalid SA=" MACSTR
++			   " in received indication - ignore this indication silently",
++			   __func__, MAC2STR(addr));
++		return 0;
++	}
++
+ 	random_add_randomness(addr, ETH_ALEN);
+ 
+ 	hostapd_logger(hapd, addr, HOSTAPD_MODULE_IEEE80211,
+diff --git a/src/ap/ieee802_11.c b/src/ap/ieee802_11.c
+index c85a28db44b7..e7065372e158 100644
+--- a/src/ap/ieee802_11.c
++++ b/src/ap/ieee802_11.c
+@@ -4626,6 +4626,18 @@ int ieee802_11_mgmt(struct hostapd_data *hapd, const u8 *buf, size_t len,
+ 	fc = le_to_host16(mgmt->frame_control);
+ 	stype = WLAN_FC_GET_STYPE(fc);
+ 
++	if (is_multicast_ether_addr(mgmt->sa) ||
++	    is_zero_ether_addr(mgmt->sa) ||
++	    os_memcmp(mgmt->sa, hapd->own_addr, ETH_ALEN) == 0) {
++		/* Do not process any frames with unexpected/invalid SA so that
++		 * we do not add any state for unexpected STA addresses or end
++		 * up sending out frames to unexpected destination. */
++		wpa_printf(MSG_DEBUG, "MGMT: Invalid SA=" MACSTR
++			   " in received frame - ignore this frame silently",
++			   MAC2STR(mgmt->sa));
++		return 0;
++	}
++
+ 	if (stype == WLAN_FC_STYPE_BEACON) {
+ 		handle_beacon(hapd, mgmt, len, fi);
+ 		return 1;
+-- 
+2.20.1
+

--- a/package/wpa_supplicant_k44/0002-ASN.1-Validate-DigestAlgorithmIdentifier-parameters.patch
+++ b/package/wpa_supplicant_k44/0002-ASN.1-Validate-DigestAlgorithmIdentifier-parameters.patch
@@ -1,0 +1,116 @@
+From a0541334a6394f8237a4393b7372693cd7e96f15 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Sat, 13 Mar 2021 18:19:31 +0200
+Subject: [PATCH] ASN.1: Validate DigestAlgorithmIdentifier parameters
+
+The supported hash algorithms do not use AlgorithmIdentifier parameters.
+However, there are implementations that include NULL parameters in
+addition to ones that omit the parameters. Previous implementation did
+not check the parameters value at all which supported both these cases,
+but did not reject any other unexpected information.
+
+Use strict validation of digest algorithm parameters and reject any
+unexpected value when validating a signature. This is needed to prevent
+potential forging attacks.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
+---
+ src/tls/pkcs1.c  | 21 +++++++++++++++++++++
+ src/tls/x509v3.c | 20 ++++++++++++++++++++
+ 2 files changed, 41 insertions(+)
+
+diff --git a/src/tls/pkcs1.c b/src/tls/pkcs1.c
+index bbdb0d72d..5761dfed0 100644
+--- a/src/tls/pkcs1.c
++++ b/src/tls/pkcs1.c
+@@ -244,6 +244,8 @@ int pkcs1_v15_sig_ver(struct crypto_public_key *pk,
+ 		os_free(decrypted);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "PKCS #1: DigestInfo",
++		    hdr.payload, hdr.length);
+ 
+ 	pos = hdr.payload;
+ 	end = pos + hdr.length;
+@@ -265,6 +267,8 @@ int pkcs1_v15_sig_ver(struct crypto_public_key *pk,
+ 		os_free(decrypted);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "PKCS #1: DigestAlgorithmIdentifier",
++		    hdr.payload, hdr.length);
+ 	da_end = hdr.payload + hdr.length;
+ 
+ 	if (asn1_get_oid(hdr.payload, hdr.length, &oid, &next)) {
+@@ -273,6 +277,23 @@ int pkcs1_v15_sig_ver(struct crypto_public_key *pk,
+ 		os_free(decrypted);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "PKCS #1: Digest algorithm parameters",
++		    next, da_end - next);
++
++	/*
++	 * RFC 5754: The correct encoding for the SHA2 algorithms would be to
++	 * omit the parameters, but there are implementation that encode these
++	 * as a NULL element. Allow these two cases and reject anything else.
++	 */
++	if (da_end > next &&
++	    (asn1_get_next(next, da_end - next, &hdr) < 0 ||
++	     !asn1_is_null(&hdr) ||
++	     hdr.payload + hdr.length != da_end)) {
++		wpa_printf(MSG_DEBUG,
++			   "PKCS #1: Unexpected digest algorithm parameters");
++		os_free(decrypted);
++		return -1;
++	}
+ 
+ 	if (!asn1_oid_equal(&oid, hash_alg)) {
+ 		char txt[100], txt2[100];
+diff --git a/src/tls/x509v3.c b/src/tls/x509v3.c
+index a8944dd2f..df337ec4d 100644
+--- a/src/tls/x509v3.c
++++ b/src/tls/x509v3.c
+@@ -1964,6 +1964,7 @@ int x509_check_signature(struct x509_certificate *issuer,
+ 		os_free(data);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "X509: DigestInfo", hdr.payload, hdr.length);
+ 
+ 	pos = hdr.payload;
+ 	end = pos + hdr.length;
+@@ -1985,6 +1986,8 @@ int x509_check_signature(struct x509_certificate *issuer,
+ 		os_free(data);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "X509: DigestAlgorithmIdentifier",
++		    hdr.payload, hdr.length);
+ 	da_end = hdr.payload + hdr.length;
+ 
+ 	if (asn1_get_oid(hdr.payload, hdr.length, &oid, &next)) {
+@@ -1992,6 +1995,23 @@ int x509_check_signature(struct x509_certificate *issuer,
+ 		os_free(data);
+ 		return -1;
+ 	}
++	wpa_hexdump(MSG_MSGDUMP, "X509: Digest algorithm parameters",
++		    next, da_end - next);
++
++	/*
++	 * RFC 5754: The correct encoding for the SHA2 algorithms would be to
++	 * omit the parameters, but there are implementation that encode these
++	 * as a NULL element. Allow these two cases and reject anything else.
++	 */
++	if (da_end > next &&
++	    (asn1_get_next(next, da_end - next, &hdr) < 0 ||
++	     !asn1_is_null(&hdr) ||
++	     hdr.payload + hdr.length != da_end)) {
++		wpa_printf(MSG_DEBUG,
++			   "X509: Unexpected digest algorithm parameters");
++		os_free(data);
++		return -1;
++	}
+ 
+ 	if (x509_sha1_oid(&oid)) {
+ 		if (signature->oid.oid[6] != 5 /* sha-1WithRSAEncryption */) {
+-- 
+2.20.1
+

--- a/package/wpa_supplicant_k44/0003-Include-stdbool.h-to-allow-C99-bool-to-be-used.patch
+++ b/package/wpa_supplicant_k44/0003-Include-stdbool.h-to-allow-C99-bool-to-be-used.patch
@@ -1,0 +1,32 @@
+From 99cf89555313056d3a8fa54b21d02dc880b363e1 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Mon, 20 Apr 2020 20:29:31 +0300
+Subject: [PATCH] Include stdbool.h to allow C99 bool to be used
+
+We have practically started requiring some C99 features, so might as
+well finally go ahead and bring in the C99 bool as well.
+
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+[geomatsi@gmail.com: backport from upstream]
+Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>
+[yann.morin.1998@free.fr: keep upstream sha1 in header, drop numbering]
+Signed-off-by: Yann E. MORIN <yann.morin.1998@free.fr>
+---
+ src/utils/includes.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/utils/includes.h b/src/utils/includes.h
+index 75513fc8c..741fc9c14 100644
+--- a/src/utils/includes.h
++++ b/src/utils/includes.h
+@@ -18,6 +18,7 @@
+ 
+ #include <stdlib.h>
+ #include <stddef.h>
++#include <stdbool.h>
+ #include <stdio.h>
+ #include <stdarg.h>
+ #include <string.h>
+-- 
+2.25.1
+

--- a/package/wpa_supplicant_k44/0004-ASN.1-Add-helper-functions-for-recognizing-tag-value.patch
+++ b/package/wpa_supplicant_k44/0004-ASN.1-Add-helper-functions-for-recognizing-tag-value.patch
@@ -1,0 +1,37 @@
+From 9a990e8c4eb92dd64e0ec483599820e45c35ac23 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Sat, 13 Mar 2021 23:14:23 +0200
+Subject: [PATCH] ASN.1: Add helper functions for recognizing tag values
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+[geomatsi@gmail.com: backport asn1_is_null() from upstream 9a990e8c4eb9]
+Signed-off-by: Sergey Matyukevich <geomatsi@gmail.com>
+[yann.morin.1998@free.fr: 
+  - reformat, keep the upstream sha1 and title,
+  - drop numbering
+]
+Signed-off-by: Yann E. MORIN <yann.morin.1998@free.fr>
+---
+ src/tls/asn1.h | 102 +++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 102 insertions(+)
+
+diff --git a/src/tls/asn1.h b/src/tls/asn1.h
+index de3430adb..a4d1be473 100644
+--- a/src/tls/asn1.h
++++ b/src/tls/asn1.h
+@@ -66,6 +66,12 @@ struct wpabuf * asn1_build_alg_id(const struct asn1_oid *oid,
+ unsigned long asn1_bit_string_to_long(const u8 *buf, size_t len);
+ int asn1_oid_equal(const struct asn1_oid *a, const struct asn1_oid *b);
+ 
++static inline bool asn1_is_null(const struct asn1_hdr *hdr)
++{
++	return hdr->class == ASN1_CLASS_UNIVERSAL &&
++		hdr->tag == ASN1_TAG_NULL;
++}
++
+ extern struct asn1_oid asn1_sha1_oid;
+ extern struct asn1_oid asn1_sha256_oid;
+ 
+-- 
+2.25.1
+

--- a/package/wpa_supplicant_k44/0005-2020-1-WPS-UPnP-Do-not-allow-event-subscriptions-with-URLs-.patch
+++ b/package/wpa_supplicant_k44/0005-2020-1-WPS-UPnP-Do-not-allow-event-subscriptions-with-URLs-.patch
@@ -1,0 +1,150 @@
+From 5b78c8f961f25f4dc22d6f2b77ddd06d712cec63 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Wed, 3 Jun 2020 23:17:35 +0300
+Subject: [PATCH 1/3] WPS UPnP: Do not allow event subscriptions with URLs to
+ other networks
+
+The UPnP Device Architecture 2.0 specification errata ("UDA errata
+16-04-2020.docx") addresses a problem with notifications being allowed
+to go out to other domains by disallowing such cases. Do such filtering
+for the notification callback URLs to avoid undesired connections to
+external networks based on subscriptions that any device in the local
+network could request when WPS support for external registrars is
+enabled (the upnp_iface parameter in hostapd configuration).
+
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+---
+ src/wps/wps_er.c     |  2 +-
+ src/wps/wps_upnp.c   | 38 ++++++++++++++++++++++++++++++++++++--
+ src/wps/wps_upnp_i.h |  3 ++-
+ 3 files changed, 39 insertions(+), 4 deletions(-)
+
+diff --git a/src/wps/wps_er.c b/src/wps/wps_er.c
+index 6bded14327f8..31d2e50e4cff 100644
+--- a/src/wps/wps_er.c
++++ b/src/wps/wps_er.c
+@@ -1298,7 +1298,7 @@ wps_er_init(struct wps_context *wps, const char *ifname, const char *filter)
+ 			   "with %s", filter);
+ 	}
+ 	if (get_netif_info(er->ifname, &er->ip_addr, &er->ip_addr_text,
+-			   er->mac_addr)) {
++			   NULL, er->mac_addr)) {
+ 		wpa_printf(MSG_INFO, "WPS UPnP: Could not get IP/MAC address "
+ 			   "for %s. Does it have IP address?", er->ifname);
+ 		wps_er_deinit(er, NULL, NULL);
+diff --git a/src/wps/wps_upnp.c b/src/wps/wps_upnp.c
+index 6e10e4bc0c3f..7d4b7439940e 100644
+--- a/src/wps/wps_upnp.c
++++ b/src/wps/wps_upnp.c
+@@ -303,6 +303,14 @@ static void subscr_addr_free_all(struct subscription *s)
+ }
+ 
+ 
++static int local_network_addr(struct upnp_wps_device_sm *sm,
++			      struct sockaddr_in *addr)
++{
++	return (addr->sin_addr.s_addr & sm->netmask.s_addr) ==
++		(sm->ip_addr & sm->netmask.s_addr);
++}
++
++
+ /* subscr_addr_add_url -- add address(es) for one url to subscription */
+ static void subscr_addr_add_url(struct subscription *s, const char *url,
+ 				size_t url_len)
+@@ -381,6 +389,7 @@ static void subscr_addr_add_url(struct subscription *s, const char *url,
+ 
+ 	for (rp = result; rp; rp = rp->ai_next) {
+ 		struct subscr_addr *a;
++		struct sockaddr_in *addr = (struct sockaddr_in *) rp->ai_addr;
+ 
+ 		/* Limit no. of address to avoid denial of service attack */
+ 		if (dl_list_len(&s->addr_list) >= MAX_ADDR_PER_SUBSCRIPTION) {
+@@ -389,6 +398,13 @@ static void subscr_addr_add_url(struct subscription *s, const char *url,
+ 			break;
+ 		}
+ 
++		if (!local_network_addr(s->sm, addr)) {
++			wpa_printf(MSG_INFO,
++				   "WPS UPnP: Ignore a delivery URL that points to another network %s",
++				   inet_ntoa(addr->sin_addr));
++			continue;
++		}
++
+ 		a = os_zalloc(sizeof(*a) + alloc_len);
+ 		if (a == NULL)
+ 			break;
+@@ -890,11 +906,12 @@ static int eth_get(const char *device, u8 ea[ETH_ALEN])
+  * @net_if: Selected network interface name
+  * @ip_addr: Buffer for returning IP address in network byte order
+  * @ip_addr_text: Buffer for returning a pointer to allocated IP address text
++ * @netmask: Buffer for returning netmask or %NULL if not needed
+  * @mac: Buffer for returning MAC address
+  * Returns: 0 on success, -1 on failure
+  */
+ int get_netif_info(const char *net_if, unsigned *ip_addr, char **ip_addr_text,
+-		   u8 mac[ETH_ALEN])
++		   struct in_addr *netmask, u8 mac[ETH_ALEN])
+ {
+ 	struct ifreq req;
+ 	int sock = -1;
+@@ -920,6 +937,19 @@ int get_netif_info(const char *net_if, unsigned *ip_addr, char **ip_addr_text,
+ 	in_addr.s_addr = *ip_addr;
+ 	os_snprintf(*ip_addr_text, 16, "%s", inet_ntoa(in_addr));
+ 
++	if (netmask) {
++		os_memset(&req, 0, sizeof(req));
++		os_strlcpy(req.ifr_name, net_if, sizeof(req.ifr_name));
++		if (ioctl(sock, SIOCGIFNETMASK, &req) < 0) {
++			wpa_printf(MSG_ERROR,
++				   "WPS UPnP: SIOCGIFNETMASK failed: %d (%s)",
++				   errno, strerror(errno));
++			goto fail;
++		}
++		addr = (struct sockaddr_in *) &req.ifr_netmask;
++		netmask->s_addr = addr->sin_addr.s_addr;
++	}
++
+ #ifdef __linux__
+ 	os_strlcpy(req.ifr_name, net_if, sizeof(req.ifr_name));
+ 	if (ioctl(sock, SIOCGIFHWADDR, &req) < 0) {
+@@ -1026,11 +1056,15 @@ static int upnp_wps_device_start(struct upnp_wps_device_sm *sm, char *net_if)
+ 
+ 	/* Determine which IP and mac address we're using */
+ 	if (get_netif_info(net_if, &sm->ip_addr, &sm->ip_addr_text,
+-			   sm->mac_addr)) {
++			   &sm->netmask, sm->mac_addr)) {
+ 		wpa_printf(MSG_INFO, "WPS UPnP: Could not get IP/MAC address "
+ 			   "for %s. Does it have IP address?", net_if);
+ 		goto fail;
+ 	}
++	wpa_printf(MSG_DEBUG, "WPS UPnP: Local IP address %s netmask %s hwaddr "
++		   MACSTR,
++		   sm->ip_addr_text, inet_ntoa(sm->netmask),
++		   MAC2STR(sm->mac_addr));
+ 
+ 	/* Listen for incoming TCP connections so that others
+ 	 * can fetch our "xml files" from us.
+diff --git a/src/wps/wps_upnp_i.h b/src/wps/wps_upnp_i.h
+index e87a93232df1..6ead7b4e9a30 100644
+--- a/src/wps/wps_upnp_i.h
++++ b/src/wps/wps_upnp_i.h
+@@ -128,6 +128,7 @@ struct upnp_wps_device_sm {
+ 	u8 mac_addr[ETH_ALEN]; /* mac addr of network i.f. we use */
+ 	char *ip_addr_text; /* IP address of network i.f. we use */
+ 	unsigned ip_addr; /* IP address of network i.f. we use (host order) */
++	struct in_addr netmask;
+ 	int multicast_sd; /* send multicast messages over this socket */
+ 	int ssdp_sd; /* receive discovery UPD packets on socket */
+ 	int ssdp_sd_registered; /* nonzero if we must unregister */
+@@ -158,7 +159,7 @@ struct subscription * subscription_find(struct upnp_wps_device_sm *sm,
+ 					const u8 uuid[UUID_LEN]);
+ void subscr_addr_delete(struct subscr_addr *a);
+ int get_netif_info(const char *net_if, unsigned *ip_addr, char **ip_addr_text,
+-		   u8 mac[ETH_ALEN]);
++		   struct in_addr *netmask, u8 mac[ETH_ALEN]);
+ 
+ /* wps_upnp_ssdp.c */
+ void msearchreply_state_machine_stop(struct advertisement_state_machine *a);
+-- 
+2.20.1
+

--- a/package/wpa_supplicant_k44/0006-2020-1-WPS-UPnP-Fix-event-message-generation-using-a-long-U.patch
+++ b/package/wpa_supplicant_k44/0006-2020-1-WPS-UPnP-Fix-event-message-generation-using-a-long-U.patch
@@ -1,0 +1,59 @@
+From f7d268864a2660b7239b9a8ff5ad37faeeb751ba Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Wed, 3 Jun 2020 22:41:02 +0300
+Subject: [PATCH 2/3] WPS UPnP: Fix event message generation using a long URL
+ path
+
+More than about 700 character URL ended up overflowing the wpabuf used
+for building the event notification and this resulted in the wpabuf
+buffer overflow checks terminating the hostapd process. Fix this by
+allocating the buffer to be large enough to contain the full URL path.
+However, since that around 700 character limit has been the practical
+limit for more than ten years, start explicitly enforcing that as the
+limit or the callback URLs since any longer ones had not worked before
+and there is no need to enable them now either.
+
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+---
+ src/wps/wps_upnp.c       | 9 +++++++--
+ src/wps/wps_upnp_event.c | 3 ++-
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/wps/wps_upnp.c b/src/wps/wps_upnp.c
+index 7d4b7439940e..ab685d52ecab 100644
+--- a/src/wps/wps_upnp.c
++++ b/src/wps/wps_upnp.c
+@@ -328,9 +328,14 @@ static void subscr_addr_add_url(struct subscription *s, const char *url,
+ 	int rerr;
+ 	size_t host_len, path_len;
+ 
+-	/* url MUST begin with http: */
+-	if (url_len < 7 || os_strncasecmp(url, "http://", 7))
++	/* URL MUST begin with HTTP scheme. In addition, limit the length of
++	 * the URL to 700 characters which is around the limit that was
++	 * implicitly enforced for more than 10 years due to a bug in
++	 * generating the event messages. */
++	if (url_len < 7 || os_strncasecmp(url, "http://", 7) || url_len > 700) {
++		wpa_printf(MSG_DEBUG, "WPS UPnP: Reject an unacceptable URL");
+ 		goto fail;
++	}
+ 	url += 7;
+ 	url_len -= 7;
+ 
+diff --git a/src/wps/wps_upnp_event.c b/src/wps/wps_upnp_event.c
+index d7e6edcc6503..08a23612f338 100644
+--- a/src/wps/wps_upnp_event.c
++++ b/src/wps/wps_upnp_event.c
+@@ -147,7 +147,8 @@ static struct wpabuf * event_build_message(struct wps_event_ *e)
+ 	struct wpabuf *buf;
+ 	char *b;
+ 
+-	buf = wpabuf_alloc(1000 + wpabuf_len(e->data));
++	buf = wpabuf_alloc(1000 + os_strlen(e->addr->path) +
++			   wpabuf_len(e->data));
+ 	if (buf == NULL)
+ 		return NULL;
+ 	wpabuf_printf(buf, "NOTIFY %s HTTP/1.1\r\n", e->addr->path);
+-- 
+2.20.1
+

--- a/package/wpa_supplicant_k44/0007-2020-1-WPS-UPnP-Handle-HTTP-initiation-failures-for-events-.patch
+++ b/package/wpa_supplicant_k44/0007-2020-1-WPS-UPnP-Handle-HTTP-initiation-failures-for-events-.patch
@@ -1,0 +1,47 @@
+From 85aac526af8612c21b3117dadc8ef5944985b476 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Thu, 4 Jun 2020 21:24:04 +0300
+Subject: [PATCH 3/3] WPS UPnP: Handle HTTP initiation failures for events more
+ properly
+
+While it is appropriate to try to retransmit the event to another
+callback URL on a failure to initiate the HTTP client connection, there
+is no point in trying the exact same operation multiple times in a row.
+Replve the event_retry() calls with event_addr_failure() for these cases
+to avoid busy loops trying to repeat the same failing operation.
+
+These potential busy loops would go through eloop callbacks, so the
+process is not completely stuck on handling them, but unnecessary CPU
+would be used to process the continues retries that will keep failing
+for the same reason.
+
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+---
+ src/wps/wps_upnp_event.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/wps/wps_upnp_event.c b/src/wps/wps_upnp_event.c
+index 08a23612f338..c0d9e41d9a38 100644
+--- a/src/wps/wps_upnp_event.c
++++ b/src/wps/wps_upnp_event.c
+@@ -294,7 +294,7 @@ static int event_send_start(struct subscription *s)
+ 
+ 	buf = event_build_message(e);
+ 	if (buf == NULL) {
+-		event_retry(e, 0);
++		event_addr_failure(e);
+ 		return -1;
+ 	}
+ 
+@@ -302,7 +302,7 @@ static int event_send_start(struct subscription *s)
+ 					 event_http_cb, e);
+ 	if (e->http_event == NULL) {
+ 		wpabuf_free(buf);
+-		event_retry(e, 0);
++		event_addr_failure(e);
+ 		return -1;
+ 	}
+ 
+-- 
+2.20.1
+

--- a/package/wpa_supplicant_k44/0008-2020-2-P2P-Fix-copying-of-secondary-device-types-for-P2P-gr.patch
+++ b/package/wpa_supplicant_k44/0008-2020-2-P2P-Fix-copying-of-secondary-device-types-for-P2P-gr.patch
@@ -1,0 +1,38 @@
+From 947272febe24a8f0ea828b5b2f35f13c3821901e Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Mon, 9 Nov 2020 11:43:12 +0200
+Subject: [PATCH] P2P: Fix copying of secondary device types for P2P group
+ client
+
+Parsing and copying of WPS secondary device types list was verifying
+that the contents is not too long for the internal maximum in the case
+of WPS messages, but similar validation was missing from the case of P2P
+group information which encodes this information in a different
+attribute. This could result in writing beyond the memory area assigned
+for these entries and corrupting memory within an instance of struct
+p2p_device. This could result in invalid operations and unexpected
+behavior when trying to free pointers from that corrupted memory.
+
+Credit to OSS-Fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=27269
+Fixes: e57ae6e19edf ("P2P: Keep track of secondary device types for peers")
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+---
+ src/p2p/p2p.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/p2p/p2p.c b/src/p2p/p2p.c
+index 74b7b52ae05c..5cbfc217fc1f 100644
+--- a/src/p2p/p2p.c
++++ b/src/p2p/p2p.c
+@@ -453,6 +453,8 @@ static void p2p_copy_client_info(struct p2p_device *dev,
+ 	dev->info.config_methods = cli->config_methods;
+ 	os_memcpy(dev->info.pri_dev_type, cli->pri_dev_type, 8);
+ 	dev->info.wps_sec_dev_type_list_len = 8 * cli->num_sec_dev_types;
++	if (dev->info.wps_sec_dev_type_list_len > WPS_SEC_DEV_TYPE_MAX_LEN)
++		dev->info.wps_sec_dev_type_list_len = WPS_SEC_DEV_TYPE_MAX_LEN;
+ 	os_memcpy(dev->info.wps_sec_dev_type_list, cli->sec_dev_types,
+ 		  dev->info.wps_sec_dev_type_list_len);
+ }
+-- 
+2.25.1
+

--- a/package/wpa_supplicant_k44/0009-2021-1-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
+++ b/package/wpa_supplicant_k44/0009-2021-1-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
@@ -1,0 +1,50 @@
+From 8460e3230988ef2ec13ce6b69b687e941f6cdb32 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Tue, 8 Dec 2020 23:52:50 +0200
+Subject: [PATCH] P2P: Fix a corner case in peer addition based on PD Request
+
+p2p_add_device() may remove the oldest entry if there is no room in the
+peer table for a new peer. This would result in any pointer to that
+removed entry becoming stale. A corner case with an invalid PD Request
+frame could result in such a case ending up using (read+write) freed
+memory. This could only by triggered when the peer table has reached its
+maximum size and the PD Request frame is received from the P2P Device
+Address of the oldest remaining entry and the frame has incorrect P2P
+Device Address in the payload.
+
+Fix this by fetching the dev pointer again after having called
+p2p_add_device() so that the stale pointer cannot be used.
+
+Fixes: 17bef1e97a50 ("P2P: Add peer entry based on Provision Discovery Request")
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+---
+ src/p2p/p2p_pd.c | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/src/p2p/p2p_pd.c b/src/p2p/p2p_pd.c
+index 3994ec03f86b..05fd593494ef 100644
+--- a/src/p2p/p2p_pd.c
++++ b/src/p2p/p2p_pd.c
+@@ -595,14 +595,12 @@ void p2p_process_prov_disc_req(struct p2p_data *p2p, const u8 *sa,
+ 			goto out;
+ 		}
+ 
++		dev = p2p_get_device(p2p, sa);
+ 		if (!dev) {
+-			dev = p2p_get_device(p2p, sa);
+-			if (!dev) {
+-				p2p_dbg(p2p,
+-					"Provision Discovery device not found "
+-					MACSTR, MAC2STR(sa));
+-				goto out;
+-			}
++			p2p_dbg(p2p,
++				"Provision Discovery device not found "
++				MACSTR, MAC2STR(sa));
++			goto out;
+ 		}
+ 	} else if (msg.wfd_subelems) {
+ 		wpabuf_free(dev->info.wfd_subelems);
+-- 
+2.25.1
+

--- a/package/wpa_supplicant_k44/0010-2022-1-crypto-Add-more-bignum-EC-helper-functions.patch
+++ b/package/wpa_supplicant_k44/0010-2022-1-crypto-Add-more-bignum-EC-helper-functions.patch
@@ -1,0 +1,318 @@
+From 208e5687ff2e48622e28d8888ce5444a54353bbd Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Tue, 27 Aug 2019 16:33:15 +0300
+Subject: [PATCH 1/4] crypto: Add more bignum/EC helper functions
+
+These are needed for implementing SAE hash-to-element.
+
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+---
+ src/crypto/crypto.h         | 45 ++++++++++++++++++
+ src/crypto/crypto_openssl.c | 94 +++++++++++++++++++++++++++++++++++++
+ src/crypto/crypto_wolfssl.c | 66 ++++++++++++++++++++++++++
+ 3 files changed, 205 insertions(+)
+
+diff --git a/src/crypto/crypto.h b/src/crypto/crypto.h
+index 15f8ad04cea4..68476dbce96c 100644
+--- a/src/crypto/crypto.h
++++ b/src/crypto/crypto.h
+@@ -518,6 +518,13 @@ struct crypto_bignum * crypto_bignum_init(void);
+  */
+ struct crypto_bignum * crypto_bignum_init_set(const u8 *buf, size_t len);
+ 
++/**
++ * crypto_bignum_init_set - Allocate memory for bignum and set the value (uint)
++ * @val: Value to set
++ * Returns: Pointer to allocated bignum or %NULL on failure
++ */
++struct crypto_bignum * crypto_bignum_init_uint(unsigned int val);
++
+ /**
+  * crypto_bignum_deinit - Free bignum
+  * @n: Bignum from crypto_bignum_init() or crypto_bignum_init_set()
+@@ -612,6 +619,19 @@ int crypto_bignum_div(const struct crypto_bignum *a,
+ 		      const struct crypto_bignum *b,
+ 		      struct crypto_bignum *c);
+ 
++/**
++ * crypto_bignum_addmod - d = a + b (mod c)
++ * @a: Bignum
++ * @b: Bignum
++ * @c: Bignum
++ * @d: Bignum; used to store the result of (a + b) % c
++ * Returns: 0 on success, -1 on failure
++ */
++int crypto_bignum_addmod(const struct crypto_bignum *a,
++			 const struct crypto_bignum *b,
++			 const struct crypto_bignum *c,
++			 struct crypto_bignum *d);
++
+ /**
+  * crypto_bignum_mulmod - d = a * b (mod c)
+  * @a: Bignum
+@@ -625,6 +645,28 @@ int crypto_bignum_mulmod(const struct crypto_bignum *a,
+ 			 const struct crypto_bignum *c,
+ 			 struct crypto_bignum *d);
+ 
++/**
++ * crypto_bignum_sqrmod - c = a^2 (mod b)
++ * @a: Bignum
++ * @b: Bignum
++ * @c: Bignum; used to store the result of a^2 % b
++ * Returns: 0 on success, -1 on failure
++ */
++int crypto_bignum_sqrmod(const struct crypto_bignum *a,
++			 const struct crypto_bignum *b,
++			 struct crypto_bignum *c);
++
++/**
++ * crypto_bignum_sqrtmod - returns sqrt(a) (mod b)
++ * @a: Bignum
++ * @b: Bignum
++ * @c: Bignum; used to store the result
++ * Returns: 0 on success, -1 on failure
++ */
++int crypto_bignum_sqrtmod(const struct crypto_bignum *a,
++			  const struct crypto_bignum *b,
++			  struct crypto_bignum *c);
++
+ /**
+  * crypto_bignum_rshift - r = a >> n
+  * @a: Bignum
+@@ -731,6 +773,9 @@ const struct crypto_bignum * crypto_ec_get_prime(struct crypto_ec *e);
+  */
+ const struct crypto_bignum * crypto_ec_get_order(struct crypto_ec *e);
+ 
++const struct crypto_bignum * crypto_ec_get_a(struct crypto_ec *e);
++const struct crypto_bignum * crypto_ec_get_b(struct crypto_ec *e);
++
+ /**
+  * struct crypto_ec_point - Elliptic curve point
+  *
+diff --git a/src/crypto/crypto_openssl.c b/src/crypto/crypto_openssl.c
+index bab33a537293..ed463105e8f1 100644
+--- a/src/crypto/crypto_openssl.c
++++ b/src/crypto/crypto_openssl.c
+@@ -1283,6 +1283,24 @@ struct crypto_bignum * crypto_bignum_init_set(const u8 *buf, size_t len)
+ }
+ 
+ 
++struct crypto_bignum * crypto_bignum_init_uint(unsigned int val)
++{
++	BIGNUM *bn;
++
++	if (TEST_FAIL())
++		return NULL;
++
++	bn = BN_new();
++	if (!bn)
++		return NULL;
++	if (BN_set_word(bn, val) != 1) {
++		BN_free(bn);
++		return NULL;
++	}
++	return (struct crypto_bignum *) bn;
++}
++
++
+ void crypto_bignum_deinit(struct crypto_bignum *n, int clear)
+ {
+ 	if (clear)
+@@ -1449,6 +1467,28 @@ int crypto_bignum_div(const struct crypto_bignum *a,
+ }
+ 
+ 
++int crypto_bignum_addmod(const struct crypto_bignum *a,
++			 const struct crypto_bignum *b,
++			 const struct crypto_bignum *c,
++			 struct crypto_bignum *d)
++{
++	int res;
++	BN_CTX *bnctx;
++
++	if (TEST_FAIL())
++		return -1;
++
++	bnctx = BN_CTX_new();
++	if (!bnctx)
++		return -1;
++	res = BN_mod_add((BIGNUM *) d, (const BIGNUM *) a, (const BIGNUM *) b,
++			 (const BIGNUM *) c, bnctx);
++	BN_CTX_free(bnctx);
++
++	return res ? 0 : -1;
++}
++
++
+ int crypto_bignum_mulmod(const struct crypto_bignum *a,
+ 			 const struct crypto_bignum *b,
+ 			 const struct crypto_bignum *c,
+@@ -1472,6 +1512,48 @@ int crypto_bignum_mulmod(const struct crypto_bignum *a,
+ }
+ 
+ 
++int crypto_bignum_sqrmod(const struct crypto_bignum *a,
++			 const struct crypto_bignum *b,
++			 struct crypto_bignum *c)
++{
++	int res;
++	BN_CTX *bnctx;
++
++	if (TEST_FAIL())
++		return -1;
++
++	bnctx = BN_CTX_new();
++	if (!bnctx)
++		return -1;
++	res = BN_mod_sqr((BIGNUM *) c, (const BIGNUM *) a, (const BIGNUM *) b,
++			 bnctx);
++	BN_CTX_free(bnctx);
++
++	return res ? 0 : -1;
++}
++
++
++int crypto_bignum_sqrtmod(const struct crypto_bignum *a,
++			  const struct crypto_bignum *b,
++			  struct crypto_bignum *c)
++{
++	BN_CTX *bnctx;
++	BIGNUM *res;
++
++	if (TEST_FAIL())
++		return -1;
++
++	bnctx = BN_CTX_new();
++	if (!bnctx)
++		return -1;
++	res = BN_mod_sqrt((BIGNUM *) c, (const BIGNUM *) a, (const BIGNUM *) b,
++			  bnctx);
++	BN_CTX_free(bnctx);
++
++	return res ? 0 : -1;
++}
++
++
+ int crypto_bignum_rshift(const struct crypto_bignum *a, int n,
+ 			 struct crypto_bignum *r)
+ {
+@@ -1682,6 +1764,18 @@ const struct crypto_bignum * crypto_ec_get_order(struct crypto_ec *e)
+ }
+ 
+ 
++const struct crypto_bignum * crypto_ec_get_a(struct crypto_ec *e)
++{
++	return (const struct crypto_bignum *) e->a;
++}
++
++
++const struct crypto_bignum * crypto_ec_get_b(struct crypto_ec *e)
++{
++	return (const struct crypto_bignum *) e->b;
++}
++
++
+ void crypto_ec_point_deinit(struct crypto_ec_point *p, int clear)
+ {
+ 	if (clear)
+diff --git a/src/crypto/crypto_wolfssl.c b/src/crypto/crypto_wolfssl.c
+index 4cedab4367cd..e9894b335e53 100644
+--- a/src/crypto/crypto_wolfssl.c
++++ b/src/crypto/crypto_wolfssl.c
+@@ -1042,6 +1042,26 @@ struct crypto_bignum * crypto_bignum_init_set(const u8 *buf, size_t len)
+ }
+ 
+ 
++struct crypto_bignum * crypto_bignum_init_uint(unsigned int val)
++{
++	mp_int *a;
++
++	if (TEST_FAIL())
++		return NULL;
++
++	a = (mp_int *) crypto_bignum_init();
++	if (!a)
++		return NULL;
++
++	if (mp_set_int(a, val) != MP_OKAY) {
++		os_free(a);
++		a = NULL;
++	}
++
++	return (struct crypto_bignum *) a;
++}
++
++
+ void crypto_bignum_deinit(struct crypto_bignum *n, int clear)
+ {
+ 	if (!n)
+@@ -1168,6 +1188,19 @@ int crypto_bignum_div(const struct crypto_bignum *a,
+ }
+ 
+ 
++int crypto_bignum_addmod(const struct crypto_bignum *a,
++			 const struct crypto_bignum *b,
++			 const struct crypto_bignum *c,
++			 struct crypto_bignum *d)
++{
++	if (TEST_FAIL())
++		return -1;
++
++	return mp_addmod((mp_int *) a, (mp_int *) b, (mp_int *) c,
++			 (mp_int *) d) == MP_OKAY ?  0 : -1;
++}
++
++
+ int crypto_bignum_mulmod(const struct crypto_bignum *a,
+ 			 const struct crypto_bignum *b,
+ 			 const struct crypto_bignum *m,
+@@ -1181,6 +1214,27 @@ int crypto_bignum_mulmod(const struct crypto_bignum *a,
+ }
+ 
+ 
++int crypto_bignum_sqrmod(const struct crypto_bignum *a,
++			 const struct crypto_bignum *b,
++			 struct crypto_bignum *c)
++{
++	if (TEST_FAIL())
++		return -1;
++
++	return mp_sqrmod((mp_int *) a, (mp_int *) b,
++			 (mp_int *) c) == MP_OKAY ?  0 : -1;
++}
++
++
++int crypto_bignum_sqrtmod(const struct crypto_bignum *a,
++			  const struct crypto_bignum *b,
++			  struct crypto_bignum *c)
++{
++	/* TODO */
++	return -1;
++}
++
++
+ int crypto_bignum_rshift(const struct crypto_bignum *a, int n,
+ 			 struct crypto_bignum *r)
+ {
+@@ -1386,6 +1440,18 @@ const struct crypto_bignum * crypto_ec_get_order(struct crypto_ec *e)
+ }
+ 
+ 
++const struct crypto_bignum * crypto_ec_get_a(struct crypto_ec *e)
++{
++	return (const struct crypto_bignum *) &e->a;
++}
++
++
++const struct crypto_bignum * crypto_ec_get_b(struct crypto_ec *e)
++{
++	return (const struct crypto_bignum *) &e->b;
++}
++
++
+ void crypto_ec_point_deinit(struct crypto_ec_point *p, int clear)
+ {
+ 	ecc_point *point = (ecc_point *) p;
+-- 
+2.25.1
+

--- a/package/wpa_supplicant_k44/0011-2022-1-dragonfly-Add-sqrt-helper-function.patch
+++ b/package/wpa_supplicant_k44/0011-2022-1-dragonfly-Add-sqrt-helper-function.patch
@@ -1,0 +1,72 @@
+From 2232d3d5f188b65dbb6c823ac62175412739eb16 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Fri, 7 Jan 2022 13:47:16 +0200
+Subject: [PATCH 2/4] dragonfly: Add sqrt() helper function
+
+This is a backport of "SAE: Move sqrt() implementation into a helper
+function" to introduce the helper function needed for the following
+patches.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/common/dragonfly.c | 34 ++++++++++++++++++++++++++++++++++
+ src/common/dragonfly.h |  2 ++
+ 2 files changed, 36 insertions(+)
+
+diff --git a/src/common/dragonfly.c b/src/common/dragonfly.c
+index 547be66f1561..1e842716668e 100644
+--- a/src/common/dragonfly.c
++++ b/src/common/dragonfly.c
+@@ -213,3 +213,37 @@ int dragonfly_generate_scalar(const struct crypto_bignum *order,
+ 		   "dragonfly: Unable to get randomness for own scalar");
+ 	return -1;
+ }
++
++
++/* res = sqrt(val) */
++int dragonfly_sqrt(struct crypto_ec *ec, const struct crypto_bignum *val,
++		   struct crypto_bignum *res)
++{
++	const struct crypto_bignum *prime;
++	struct crypto_bignum *tmp, *one;
++	int ret = 0;
++	u8 prime_bin[DRAGONFLY_MAX_ECC_PRIME_LEN];
++	size_t prime_len;
++
++	/* For prime p such that p = 3 mod 4, sqrt(w) = w^((p+1)/4) mod p */
++
++	prime = crypto_ec_get_prime(ec);
++	prime_len = crypto_ec_prime_len(ec);
++	tmp = crypto_bignum_init();
++	one = crypto_bignum_init_uint(1);
++
++	if (crypto_bignum_to_bin(prime, prime_bin, sizeof(prime_bin),
++				 prime_len) < 0 ||
++	    (prime_bin[prime_len - 1] & 0x03) != 3 ||
++	    !tmp || !one ||
++	    /* tmp = (p+1)/4 */
++	    crypto_bignum_add(prime, one, tmp) < 0 ||
++	    crypto_bignum_rshift(tmp, 2, tmp) < 0 ||
++	    /* res = sqrt(val) */
++	    crypto_bignum_exptmod(val, tmp, prime, res) < 0)
++		ret = -1;
++
++	crypto_bignum_deinit(tmp, 0);
++	crypto_bignum_deinit(one, 0);
++	return ret;
++}
+diff --git a/src/common/dragonfly.h b/src/common/dragonfly.h
+index ec3dd593eda4..84d67f575c54 100644
+--- a/src/common/dragonfly.h
++++ b/src/common/dragonfly.h
+@@ -27,5 +27,7 @@ int dragonfly_generate_scalar(const struct crypto_bignum *order,
+ 			      struct crypto_bignum *_rand,
+ 			      struct crypto_bignum *_mask,
+ 			      struct crypto_bignum *scalar);
++int dragonfly_sqrt(struct crypto_ec *ec, const struct crypto_bignum *val,
++		   struct crypto_bignum *res);
+ 
+ #endif /* DRAGONFLY_H */
+-- 
+2.25.1
+

--- a/package/wpa_supplicant_k44/0012-2022-1-SAE-Derive-the-y-coordinate-for-PWE-with-own-impleme.patch
+++ b/package/wpa_supplicant_k44/0012-2022-1-SAE-Derive-the-y-coordinate-for-PWE-with-own-impleme.patch
@@ -1,0 +1,99 @@
+From fe534b0baaa8c0e6ddeb24cf529d6e50e33dc501 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Fri, 7 Jan 2022 13:47:16 +0200
+Subject: [PATCH 3/4] SAE: Derive the y coordinate for PWE with own
+ implementation
+
+The crypto_ec_point_solve_y_coord() wrapper function might not use
+constant time operations in the crypto library and as such, could leak
+side channel information about the password that is used to generate the
+PWE in the hunting and pecking loop. As such, calculate the two possible
+y coordinate values and pick the correct one to use with constant time
+selection.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/common/sae.c | 47 +++++++++++++++++++++++++++++++++--------------
+ 1 file changed, 33 insertions(+), 14 deletions(-)
+
+diff --git a/src/common/sae.c b/src/common/sae.c
+index 08fdbfd18173..8d79ed962768 100644
+--- a/src/common/sae.c
++++ b/src/common/sae.c
+@@ -286,14 +286,16 @@ static int sae_derive_pwe_ecc(struct sae_data *sae, const u8 *addr1,
+ 	int pwd_seed_odd = 0;
+ 	u8 prime[SAE_MAX_ECC_PRIME_LEN];
+ 	size_t prime_len;
+-	struct crypto_bignum *x = NULL, *qr = NULL, *qnr = NULL;
++	struct crypto_bignum *x = NULL, *y = NULL, *qr = NULL, *qnr = NULL;
+ 	u8 x_bin[SAE_MAX_ECC_PRIME_LEN];
+ 	u8 x_cand_bin[SAE_MAX_ECC_PRIME_LEN];
+ 	u8 qr_bin[SAE_MAX_ECC_PRIME_LEN];
+ 	u8 qnr_bin[SAE_MAX_ECC_PRIME_LEN];
++	u8 x_y[2 * SAE_MAX_ECC_PRIME_LEN];
+ 	int res = -1;
+ 	u8 found = 0; /* 0 (false) or 0xff (true) to be used as const_time_*
+ 		       * mask */
++	unsigned int is_eq;
+ 
+ 	os_memset(x_bin, 0, sizeof(x_bin));
+ 
+@@ -402,25 +404,42 @@ static int sae_derive_pwe_ecc(struct sae_data *sae, const u8 *addr1,
+ 		goto fail;
+ 	}
+ 
+-	if (!sae->tmp->pwe_ecc)
+-		sae->tmp->pwe_ecc = crypto_ec_point_init(sae->tmp->ec);
+-	if (!sae->tmp->pwe_ecc)
+-		res = -1;
+-	else
+-		res = crypto_ec_point_solve_y_coord(sae->tmp->ec,
+-						    sae->tmp->pwe_ecc, x,
+-						    pwd_seed_odd);
+-	if (res < 0) {
+-		/*
+-		 * This should not happen since we already checked that there
+-		 * is a result.
+-		 */
++	/* y = sqrt(x^3 + ax + b) mod p
++	 * if LSB(save) == LSB(y): PWE = (x, y)
++	 * else: PWE = (x, p - y)
++	 *
++	 * Calculate y and the two possible values for PWE and after that,
++	 * use constant time selection to copy the correct alternative.
++	 */
++	y = crypto_ec_point_compute_y_sqr(sae->tmp->ec, x);
++	if (!y ||
++	    dragonfly_sqrt(sae->tmp->ec, y, y) < 0 ||
++	    crypto_bignum_to_bin(y, x_y, SAE_MAX_ECC_PRIME_LEN,
++				 prime_len) < 0 ||
++	    crypto_bignum_sub(sae->tmp->prime, y, y) < 0 ||
++	    crypto_bignum_to_bin(y, x_y + SAE_MAX_ECC_PRIME_LEN,
++				 SAE_MAX_ECC_PRIME_LEN, prime_len) < 0) {
+ 		wpa_printf(MSG_DEBUG, "SAE: Could not solve y");
++		goto fail;
++	}
++
++	is_eq = const_time_eq(pwd_seed_odd, x_y[prime_len - 1] & 0x01);
++	const_time_select_bin(is_eq, x_y, x_y + SAE_MAX_ECC_PRIME_LEN,
++			      prime_len, x_y + prime_len);
++	os_memcpy(x_y, x_bin, prime_len);
++	wpa_hexdump_key(MSG_DEBUG, "SAE: PWE", x_y, 2 * prime_len);
++	crypto_ec_point_deinit(sae->tmp->pwe_ecc, 1);
++	sae->tmp->pwe_ecc = crypto_ec_point_from_bin(sae->tmp->ec, x_y);
++	if (!sae->tmp->pwe_ecc) {
++		wpa_printf(MSG_DEBUG, "SAE: Could not generate PWE");
++		res = -1;
+ 	}
+ 
+ fail:
++	forced_memzero(x_y, sizeof(x_y));
+ 	crypto_bignum_deinit(qr, 0);
+ 	crypto_bignum_deinit(qnr, 0);
++	crypto_bignum_deinit(y, 1);
+ 	os_free(dummy_password);
+ 	bin_clear_free(tmp_password, password_len);
+ 	crypto_bignum_deinit(x, 1);
+-- 
+2.25.1
+

--- a/package/wpa_supplicant_k44/0013-2022-1-EAP-pwd-Derive-the-y-coordinate-for-PWE-with-own-imp.patch
+++ b/package/wpa_supplicant_k44/0013-2022-1-EAP-pwd-Derive-the-y-coordinate-for-PWE-with-own-imp.patch
@@ -1,0 +1,113 @@
+From 603cd880e7f90595482658a7136fa6a7be5cb485 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <j@w1.fi>
+Date: Fri, 7 Jan 2022 18:52:27 +0200
+Subject: [PATCH 4/4] EAP-pwd: Derive the y coordinate for PWE with own
+ implementation
+
+The crypto_ec_point_solve_y_coord() wrapper function might not use
+constant time operations in the crypto library and as such, could leak
+side channel information about the password that is used to generate the
+PWE in the hunting and pecking loop. As such, calculate the two possible
+y coordinate values and pick the correct one to use with constant time
+selection.
+
+Signed-off-by: Jouni Malinen <j@w1.fi>
+---
+ src/eap_common/eap_pwd_common.c | 46 ++++++++++++++++++++++++++-------
+ 1 file changed, 36 insertions(+), 10 deletions(-)
+
+diff --git a/src/eap_common/eap_pwd_common.c b/src/eap_common/eap_pwd_common.c
+index 2b2b8efdbd01..ff22b29b087a 100644
+--- a/src/eap_common/eap_pwd_common.c
++++ b/src/eap_common/eap_pwd_common.c
+@@ -127,7 +127,8 @@ int compute_password_element(EAP_PWD_group *grp, u16 num,
+ 	u8 qr_or_qnr_bin[MAX_ECC_PRIME_LEN];
+ 	u8 x_bin[MAX_ECC_PRIME_LEN];
+ 	u8 prime_bin[MAX_ECC_PRIME_LEN];
+-	struct crypto_bignum *tmp2 = NULL;
++	u8 x_y[2 * MAX_ECC_PRIME_LEN];
++	struct crypto_bignum *tmp2 = NULL, *y = NULL;
+ 	struct crypto_hash *hash;
+ 	unsigned char pwe_digest[SHA256_MAC_LEN], *prfbuf = NULL, ctr;
+ 	int ret = 0, res;
+@@ -139,6 +140,7 @@ int compute_password_element(EAP_PWD_group *grp, u16 num,
+ 	u8 found_ctr = 0, is_odd = 0;
+ 	int cmp_prime;
+ 	unsigned int in_range;
++	unsigned int is_eq;
+ 
+ 	if (grp->pwe)
+ 		return -1;
+@@ -151,11 +153,6 @@ int compute_password_element(EAP_PWD_group *grp, u16 num,
+ 	if (crypto_bignum_to_bin(prime, prime_bin, sizeof(prime_bin),
+ 				 primebytelen) < 0)
+ 		return -1;
+-	grp->pwe = crypto_ec_point_init(grp->group);
+-	if (!grp->pwe) {
+-		wpa_printf(MSG_INFO, "EAP-pwd: unable to create bignums");
+-		goto fail;
+-	}
+ 
+ 	if ((prfbuf = os_malloc(primebytelen)) == NULL) {
+ 		wpa_printf(MSG_INFO, "EAP-pwd: unable to malloc space for prf "
+@@ -261,10 +258,37 @@ int compute_password_element(EAP_PWD_group *grp, u16 num,
+ 	 */
+ 	crypto_bignum_deinit(x_candidate, 1);
+ 	x_candidate = crypto_bignum_init_set(x_bin, primebytelen);
+-	if (!x_candidate ||
+-	    crypto_ec_point_solve_y_coord(grp->group, grp->pwe, x_candidate,
+-					  is_odd) != 0) {
+-		wpa_printf(MSG_INFO, "EAP-pwd: Could not solve for y");
++	if (!x_candidate)
++		goto fail;
++
++	/* y = sqrt(x^3 + ax + b) mod p
++	 * if LSB(y) == LSB(pwd-seed): PWE = (x, y)
++	 * else: PWE = (x, p - y)
++	 *
++	 * Calculate y and the two possible values for PWE and after that,
++	 * use constant time selection to copy the correct alternative.
++	 */
++	y = crypto_ec_point_compute_y_sqr(grp->group, x_candidate);
++	if (!y ||
++	    dragonfly_sqrt(grp->group, y, y) < 0 ||
++	    crypto_bignum_to_bin(y, x_y, MAX_ECC_PRIME_LEN, primebytelen) < 0 ||
++	    crypto_bignum_sub(prime, y, y) < 0 ||
++	    crypto_bignum_to_bin(y, x_y + MAX_ECC_PRIME_LEN,
++				 MAX_ECC_PRIME_LEN, primebytelen) < 0) {
++		wpa_printf(MSG_DEBUG, "SAE: Could not solve y");
++		goto fail;
++	}
++
++	/* Constant time selection of the y coordinate from the two
++	 * options */
++	is_eq = const_time_eq(is_odd, x_y[primebytelen - 1] & 0x01);
++	const_time_select_bin(is_eq, x_y, x_y + MAX_ECC_PRIME_LEN,
++			      primebytelen, x_y + primebytelen);
++	os_memcpy(x_y, x_bin, primebytelen);
++	wpa_hexdump_key(MSG_DEBUG, "EAP-pwd: PWE", x_y, 2 * primebytelen);
++	grp->pwe = crypto_ec_point_from_bin(grp->group, x_y);
++	if (!grp->pwe) {
++		wpa_printf(MSG_DEBUG, "EAP-pwd: Could not generate PWE");
+ 		goto fail;
+ 	}
+ 
+@@ -289,6 +313,7 @@ int compute_password_element(EAP_PWD_group *grp, u16 num,
+ 	/* cleanliness and order.... */
+ 	crypto_bignum_deinit(x_candidate, 1);
+ 	crypto_bignum_deinit(tmp2, 1);
++	crypto_bignum_deinit(y, 1);
+ 	crypto_bignum_deinit(qr, 1);
+ 	crypto_bignum_deinit(qnr, 1);
+ 	bin_clear_free(prfbuf, primebytelen);
+@@ -296,6 +321,7 @@ int compute_password_element(EAP_PWD_group *grp, u16 num,
+ 	os_memset(qnr_bin, 0, sizeof(qnr_bin));
+ 	os_memset(qr_or_qnr_bin, 0, sizeof(qr_or_qnr_bin));
+ 	os_memset(pwe_digest, 0, sizeof(pwe_digest));
++	forced_memzero(x_y, sizeof(x_y));
+ 
+ 	return ret;
+ }
+-- 
+2.25.1
+

--- a/package/wpa_supplicant_k44/50-wpa_supplicant.preset
+++ b/package/wpa_supplicant_k44/50-wpa_supplicant.preset
@@ -1,0 +1,4 @@
+disable wpa_supplicant@.service
+disable wpa_supplicant-nl80211@.service
+disable wpa_supplicant-wired@.service
+

--- a/package/wpa_supplicant_k44/Config.in
+++ b/package/wpa_supplicant_k44/Config.in
@@ -1,0 +1,162 @@
+menuconfig BR2_PACKAGE_WPA_SUPPLICANT_K44
+	bool "wpa_supplicant_k44"
+	depends on BR2_USE_MMU # fork()
+	select BR2_PACKAGE_LIBOPENSSL_ENABLE_DES if BR2_PACKAGE_LIBOPENSSL
+	select BR2_PACKAGE_LIBOPENSSL_ENABLE_MD4 if BR2_PACKAGE_LIBOPENSSL
+	help
+	  WPA supplicant for secure wireless networks
+
+	  http://w1.fi/wpa_supplicant/
+
+if BR2_PACKAGE_WPA_SUPPLICANT_K44
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_NL80211
+	bool "Enable nl80211 support"
+	default y
+	depends on BR2_TOOLCHAIN_HAS_THREADS # libnl
+	select BR2_PACKAGE_LIBNL
+	help
+	  Enable support for nl80211.  This is the current wireless
+	  API for Linux, supported by all wireless drivers in vanilla
+	  Linux, but may not be supported by some out-of-tree Linux
+	  wireless drivers.  wpa_supplicant will still fall back to
+	  using the Wireless Extensions (wext) API with these drivers.
+
+	  If this option is disabled, then only the deprecated wext
+	  API will be supported, with far less features.  Linux may
+	  supports using wext with modern drivers using a
+	  compatibility layer, but it must be enabled in the kernel
+	  configuration.
+
+comment "nl80211 support needs a toolchain w/ threads"
+	depends on !BR2_TOOLCHAIN_HAS_THREADS
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_WEXT
+	bool "Enable wext (deprecated)"
+	default y if !BR2_TOOLCHAIN_HAS_THREADS
+	help
+	  Enable support for wext.  This is the historic wireless API
+	  for Linux, which is now deprecated and in maintenance-only in
+	  the kernel.  It may still be required by out-of-tree drivers.
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_WIRED
+	bool "Enable wired support"
+	select BR2_PACKAGE_WPA_SUPPLICANT_K44_EAP
+	help
+	  Include the "wired" driver, so the internal IEEE 802.1x
+	  supplicant can be used with Ethernet.  This also enables
+	  support for MACSEC.
+
+comment "wpa_supplicant will be useless without at least one driver"
+	depends on !BR2_PACKAGE_WPA_SUPPLICANT_K44_NL80211 && \
+		!BR2_PACKAGE_WPA_SUPPLICANT_K44_WEXT && \
+		!BR2_PACKAGE_WPA_SUPPLICANT_K44_WIRED
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_IBSS_RSN
+	bool "Enable IBSS RSN"
+	depends on BR2_PACKAGE_WPA_SUPPLICANT_K44_NL80211
+	help
+	  Enable support for RSN/WPA2 in Ad-Hoc mode.
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_AP_SUPPORT
+	bool "Enable AP mode"
+	depends on BR2_PACKAGE_WPA_SUPPLICANT_K44_NL80211
+	help
+	  With this option enabled, wpa_supplicant can act as an
+	  access point much like hostapd does with a limited feature
+	  set.  This links in parts of hostapd functionality into
+	  wpa_supplicant, making it bigger but dispensing the need for
+	  a separate hostapd binary in some applications hence being
+	  smaller overall.  It also enables support for Wi-Fi Direct.
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_WIFI_DISPLAY
+	bool "Enable Wi-Fi Display"
+	depends on BR2_PACKAGE_WPA_SUPPLICANT_K44_AP_SUPPORT
+	help
+	  Enable support for Wi-Fi Display
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_MESH_NETWORKING
+	bool "Enable mesh networking"
+	depends on BR2_PACKAGE_WPA_SUPPLICANT_K44_AP_SUPPORT
+	select BR2_PACKAGE_OPENSSL
+	select BR2_PACKAGE_OPENSSL_FORCE_LIBOPENSSL
+	help
+	  Enable support for open and secured mesh networking
+	  (IEEE 802.11s)
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_AUTOSCAN
+	bool "Enable autoscan"
+	help
+	  Enable support for the autoscan feature (allow periodic scan)
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_EAP
+	bool "Enable EAP"
+	help
+	  Enable support for EAP, 802.1x/WPA-Enterprise and FILS.
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_HOTSPOT
+	bool "Enable HS20"
+	select BR2_PACKAGE_WPA_SUPPLICANT_K44_EAP
+	help
+	  Enable Hotspot 2.0 and IEEE 802.11u interworking
+	  functionality.
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_DEBUG_SYSLOG
+	bool "Enable syslog support"
+	help
+	  Enable support for sending debug messages to syslog.
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_WPS
+	bool "Enable WPS"
+	help
+	  Enable support for Wi-Fi Protected Setup (WPS).
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_WPA3
+	bool "Enable WPA3 support"
+	select BR2_PACKAGE_OPENSSL
+	select BR2_PACKAGE_OPENSSL_FORCE_LIBOPENSSL
+	help
+	  Enable WPA3 support including OWE, SAE, DPP
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_CLI
+	bool "Install wpa_cli binary"
+	select BR2_PACKAGE_WPA_SUPPLICANT_K44_CTRL_IFACE
+	help
+	  Install wpa_cli command line utility
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_WPA_CLIENT_SO
+	bool "Install wpa_client shared library"
+	depends on !BR2_STATIC_LIBS
+	help
+	  Install libwpa_client.so.
+
+comment "wpa_client library needs a toolchain w/ dynamic library"
+	depends on BR2_STATIC_LIBS
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_PASSPHRASE
+	bool "Install wpa_passphrase binary"
+	help
+	  Install wpa_passphrase command line utility.
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_CTRL_IFACE
+	bool "Enable the Unix-socket control interface"
+	help
+	  Enable support for the Unix-socket-based API.
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_DBUS
+	bool "Enable support for the DBus control interface"
+	depends on BR2_TOOLCHAIN_HAS_THREADS # dbus
+	select BR2_PACKAGE_DBUS
+	help
+	  Enable support for the DBus control interface.
+
+comment "dbus support needs a toolchain w/ threads"
+	depends on !BR2_TOOLCHAIN_HAS_THREADS
+
+config BR2_PACKAGE_WPA_SUPPLICANT_K44_DBUS_INTROSPECTION
+	bool "Introspection support"
+	depends on BR2_PACKAGE_WPA_SUPPLICANT_K44_DBUS
+	help
+	  Add introspection support for the DBus control interface.
+
+endif

--- a/package/wpa_supplicant_k44/wpa_supplicant.conf
+++ b/package/wpa_supplicant_k44/wpa_supplicant.conf
@@ -1,0 +1,6 @@
+ctrl_interface=/var/run/wpa_supplicant
+ap_scan=1
+
+network={
+  key_mgmt=NONE
+}

--- a/package/wpa_supplicant_k44/wpa_supplicant_44.mk
+++ b/package/wpa_supplicant_k44/wpa_supplicant_44.mk
@@ -7,9 +7,6 @@
 WPA_SUPPLICANT_K44_VERSION = 2.9
 WPA_SUPPLICANT_K44_SITE = http://w1.fi/releases
 WPA_SUPPLICANT_K44_SOURCE = wpa_supplicant-$(WPA_SUPPLICANT_K44_VERSION).tar.gz
-WPA_SUPPLICANT_K44_PATCH = \
-	https://w1.fi/security/2020-2/0001-P2P-Fix-copying-of-secondary-device-types-for-P2P-gr.patch \
-	https://w1.fi/security/2021-1/0001-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
 WPA_SUPPLICANT_K44_LICENSE = BSD-3-Clause
 WPA_SUPPLICANT_K44_LICENSE_FILES = README
 WPA_SUPPLICANT_K44_CPE_ID_VENDOR = w1.fi
@@ -20,10 +17,10 @@ WPA_SUPPLICANT_K44_CFLAGS = $(TARGET_CFLAGS) -I$(STAGING_DIR)/usr/include/libnl3
 WPA_SUPPLICANT_K44_LDFLAGS = $(TARGET_LDFLAGS)
 WPA_SUPPLICANT_K44_SELINUX_MODULES = networkmanager
 
-# 0001-AP-Silently-ignore-management-frame-from-unexpected-.patch
+# 0001-2019-7-AP-Silently-ignore-management-frame-from-unexpected-.patch
 WPA_SUPPLICANT_K44_IGNORE_CVES += CVE-2019-16275
 
-# 0001-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
+# 0009-2021-1-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
 WPA_SUPPLICANT_K44_IGNORE_CVES += CVE-2021-27803
 
 # 0002-ASN.1-Validate-DigestAlgorithmIdentifier-parameters.patch

--- a/package/wpa_supplicant_k44/wpa_supplicant_44.mk
+++ b/package/wpa_supplicant_k44/wpa_supplicant_44.mk
@@ -1,0 +1,262 @@
+################################################################################
+#
+# wpa_supplicant for kernel 4.4
+#
+################################################################################
+
+WPA_SUPPLICANT_K44_VERSION = 2.9
+WPA_SUPPLICANT_K44_SITE = http://w1.fi/releases
+WPA_SUPPLICANT_K44_SOURCE = wpa_supplicant-$(WPA_SUPPLICANT_K44_VERSION).tar.gz
+WPA_SUPPLICANT_K44_PATCH = \
+	https://w1.fi/security/2020-2/0001-P2P-Fix-copying-of-secondary-device-types-for-P2P-gr.patch \
+	https://w1.fi/security/2021-1/0001-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
+WPA_SUPPLICANT_K44_LICENSE = BSD-3-Clause
+WPA_SUPPLICANT_K44_LICENSE_FILES = README
+WPA_SUPPLICANT_K44_CPE_ID_VENDOR = w1.fi
+WPA_SUPPLICANT_K44_CONFIG = $(WPA_SUPPLICANT_K44_DIR)/wpa_supplicant/.config
+WPA_SUPPLICANT_K44_SUBDIR = wpa_supplicant
+WPA_SUPPLICANT_K44_DBUS_SERVICE = fi.w1.wpa_supplicant1
+WPA_SUPPLICANT_K44_CFLAGS = $(TARGET_CFLAGS) -I$(STAGING_DIR)/usr/include/libnl3/
+WPA_SUPPLICANT_K44_LDFLAGS = $(TARGET_LDFLAGS)
+WPA_SUPPLICANT_K44_SELINUX_MODULES = networkmanager
+
+# 0001-AP-Silently-ignore-management-frame-from-unexpected-.patch
+WPA_SUPPLICANT_K44_IGNORE_CVES += CVE-2019-16275
+
+# 0001-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
+WPA_SUPPLICANT_K44_IGNORE_CVES += CVE-2021-27803
+
+# 0002-ASN.1-Validate-DigestAlgorithmIdentifier-parameters.patch
+WPA_SUPPLICANT_K44_IGNORE_CVES += CVE-2021-30004
+
+# install the wpa_client library
+WPA_SUPPLICANT_K44_INSTALL_STAGING = YES
+
+WPA_SUPPLICANT_K44_CONFIG_EDITS =
+
+WPA_SUPPLICANT_K44_CONFIG_ENABLE = \
+	CONFIG_INTERNAL_LIBTOMMATH \
+	CONFIG_MATCH_IFACE
+
+WPA_SUPPLICANT_K44_CONFIG_DISABLE = \
+	CONFIG_SMARTCARD
+
+# libnl-3 needs -lm (for rint) and -lpthread if linking statically
+# And library order matters hence stick -lnl-3 first since it's appended
+# in the wpa_supplicant Makefiles as in LIBS+=-lnl-3 ... thus failing
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_NL80211),y)
+ifeq ($(BR2_STATIC_LIBS),y)
+WPA_SUPPLICANT_K44_LIBS += -lnl-3 -lm -lpthread
+endif
+WPA_SUPPLICANT_K44_DEPENDENCIES += host-pkgconf libnl
+WPA_SUPPLICANT_K44_CONFIG_ENABLE += CONFIG_LIBNL32
+else
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_DRIVER_NL80211
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_WEXT),)
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_DRIVER_WEXT
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_IBSS_RSN), )
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_IBSS_RSN
+endif
+
+# Trailing underscore on purpose to not enable CONFIG_EAPOL_TEST
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_EAP),y)
+WPA_SUPPLICANT_K44_CONFIG_ENABLE += CONFIG_EAP_
+# uses dlopen()
+ifeq ($(BR2_STATIC_LIBS),y)
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_EAP_TNC
+endif
+else
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += \
+	CONFIG_EAP \
+	CONFIG_IEEE8021X_EAPOL \
+	CONFIG_FILS
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_WIRED),)
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += \
+	CONFIG_DRIVER_WIRED \
+	CONFIG_MACSEC \
+	CONFIG_DRIVER_MACSEC
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_HOTSPOT),)
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += \
+	CONFIG_HS20 \
+	CONFIG_INTERWORKING
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_AP_SUPPORT),y)
+WPA_SUPPLICANT_K44_CONFIG_ENABLE += \
+	CONFIG_AP \
+	CONFIG_P2P
+else
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += \
+	CONFIG_AP \
+	CONFIG_P2P
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_WIFI_DISPLAY),y)
+WPA_SUPPLICANT_K44_CONFIG_ENABLE += CONFIG_WIFI_DISPLAY
+else
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_WIFI_DISPLAY
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_MESH_NETWORKING),)
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_MESH
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_AUTOSCAN),y)
+WPA_SUPPLICANT_K44_CONFIG_ENABLE += \
+	CONFIG_AUTOSCAN_EXPONENTIAL \
+	CONFIG_AUTOSCAN_PERIODIC
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_WPS),)
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_WPS
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_WPA3),y)
+WPA_SUPPLICANT_K44_CONFIG_ENABLE += \
+	CONFIG_DPP \
+	CONFIG_SAE \
+	CONFIG_OWE
+else
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += \
+	CONFIG_DPP \
+	CONFIG_SAE \
+	CONFIG_OWE
+endif
+
+# Try to use openssl if it's already available
+ifeq ($(BR2_PACKAGE_LIBOPENSSL),y)
+WPA_SUPPLICANT_K44_DEPENDENCIES += host-pkgconf libopenssl
+WPA_SUPPLICANT_K44_LIBS += `$(PKG_CONFIG_HOST_BINARY) --libs openssl`
+WPA_SUPPLICANT_K44_CONFIG_EDITS += 's/\#\(CONFIG_TLS=openssl\)/\1/'
+else
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_EAP_PWD CONFIG_EAP_TEAP
+WPA_SUPPLICANT_K44_CONFIG_EDITS += 's/\#\(CONFIG_TLS=\).*/\1internal/'
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_CTRL_IFACE),)
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_CTRL_IFACE\>
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_DBUS),y)
+WPA_SUPPLICANT_K44_DEPENDENCIES += host-pkgconf dbus
+WPA_SUPPLICANT_K44_MAKE_ENV = \
+	PKG_CONFIG_SYSROOT_DIR="$(STAGING_DIR)" \
+	PKG_CONFIG_PATH="$(STAGING_DIR)/usr/lib/pkgconfig"
+WPA_SUPPLICANT_K44_CONFIG_ENABLE += CONFIG_CTRL_IFACE_DBUS_NEW
+define WPA_SUPPLICANT_K44_INSTALL_DBUS_NEW
+	$(INSTALL) -m 0644 -D \
+		$(@D)/wpa_supplicant/dbus/$(WPA_SUPPLICANT_K44_DBUS_SERVICE).service \
+		$(TARGET_DIR)/usr/share/dbus-1/system-services/$(WPA_SUPPLICANT_K44_DBUS_SERVICE).service
+endef
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_DBUS_INTROSPECTION),y)
+WPA_SUPPLICANT_K44_CONFIG_ENABLE += CONFIG_CTRL_IFACE_DBUS_INTRO
+endif
+
+else
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_CTRL_IFACE_DBUS_NEW
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_DEBUG_SYSLOG),)
+WPA_SUPPLICANT_K44_CONFIG_DISABLE += CONFIG_DEBUG_SYSLOG
+endif
+
+ifeq ($(BR2_PACKAGE_READLINE),y)
+WPA_SUPPLICANT_K44_DEPENDENCIES += readline
+WPA_SUPPLICANT_K44_CONFIG_ENABLE += CONFIG_READLINE
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_WPA_CLIENT_SO),y)
+WPA_SUPPLICANT_K44_CONFIG_SET += CONFIG_BUILD_WPA_CLIENT_SO
+define WPA_SUPPLICANT_K44_INSTALL_WPA_CLIENT_SO
+	$(INSTALL) -m 0644 -D $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)/libwpa_client.so \
+		$(TARGET_DIR)/usr/lib/libwpa_client.so
+	$(INSTALL) -m 0644 -D $(@D)/src/common/wpa_ctrl.h \
+		$(TARGET_DIR)/usr/include/wpa_ctrl.h
+endef
+define WPA_SUPPLICANT_K44_INSTALL_STAGING_WPA_CLIENT_SO
+	$(INSTALL) -m 0644 -D $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)/libwpa_client.so \
+		$(STAGING_DIR)/usr/lib/libwpa_client.so
+	$(INSTALL) -m 0644 -D $(@D)/src/common/wpa_ctrl.h \
+		$(STAGING_DIR)/usr/include/wpa_ctrl.h
+endef
+endif
+
+define WPA_SUPPLICANT_K44_CONFIGURE_CMDS
+	cp $(@D)/wpa_supplicant/defconfig $(WPA_SUPPLICANT_K44_CONFIG)
+	sed -i $(patsubst %,-e 's/^#\(%\)/\1/',$(WPA_SUPPLICANT_K44_CONFIG_ENABLE)) \
+		$(patsubst %,-e 's/^\(%\)/#\1/',$(WPA_SUPPLICANT_K44_CONFIG_DISABLE)) \
+		$(patsubst %,-e '1i%=y',$(WPA_SUPPLICANT_K44_CONFIG_SET)) \
+		$(patsubst %,-e %,$(WPA_SUPPLICANT_K44_CONFIG_EDITS)) \
+		$(WPA_SUPPLICANT_K44_CONFIG)
+endef
+
+# LIBS for wpa_supplicant, LIBS_c for wpa_cli, LIBS_p for wpa_passphrase
+define WPA_SUPPLICANT_K44_BUILD_CMDS
+	$(TARGET_MAKE_ENV) CFLAGS="$(WPA_SUPPLICANT_K44_CFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS)" BINDIR=/usr/sbin \
+		LIBS="$(WPA_SUPPLICANT_K44_LIBS)" LIBS_c="$(WPA_SUPPLICANT_K44_LIBS)" \
+		LIBS_p="$(WPA_SUPPLICANT_K44_LIBS)" \
+		$(MAKE) CC="$(TARGET_CC)" -C $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)
+endef
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_CLI),y)
+define WPA_SUPPLICANT_K44_INSTALL_CLI
+	$(INSTALL) -m 0755 -D $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)/wpa_cli \
+		$(TARGET_DIR)/usr/sbin/wpa_cli
+endef
+endif
+
+ifeq ($(BR2_PACKAGE_WPA_SUPPLICANT_K44_PASSPHRASE),y)
+define WPA_SUPPLICANT_K44_INSTALL_PASSPHRASE
+	$(INSTALL) -m 0755 -D $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)/wpa_passphrase \
+		$(TARGET_DIR)/usr/sbin/wpa_passphrase
+endef
+endif
+
+ifeq ($(BR2_PACKAGE_DBUS),y)
+define WPA_SUPPLICANT_K44_INSTALL_DBUS
+	$(INSTALL) -m 0644 -D \
+		$(@D)/wpa_supplicant/dbus/dbus-wpa_supplicant.conf \
+		$(TARGET_DIR)/etc/dbus-1/system.d/wpa_supplicant.conf
+	$(WPA_SUPPLICANT_K44_INSTALL_DBUS_NEW)
+endef
+endif
+
+define WPA_SUPPLICANT_K44_INSTALL_STAGING_CMDS
+	$(WPA_SUPPLICANT_K44_INSTALL_STAGING_WPA_CLIENT_SO)
+endef
+
+define WPA_SUPPLICANT_K44_INSTALL_TARGET_CMDS
+	$(INSTALL) -m 0755 -D $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)/wpa_supplicant \
+		$(TARGET_DIR)/usr/sbin/wpa_supplicant
+	$(INSTALL) -m 644 -D package/wpa_supplicant/wpa_supplicant.conf \
+		$(TARGET_DIR)/etc/wpa_supplicant.conf
+	$(WPA_SUPPLICANT_K44_INSTALL_CLI)
+	$(WPA_SUPPLICANT_K44_INSTALL_PASSPHRASE)
+	$(WPA_SUPPLICANT_K44_INSTALL_DBUS)
+	$(WPA_SUPPLICANT_K44_INSTALL_WPA_CLIENT_SO)
+endef
+
+define WPA_SUPPLICANT_K44_INSTALL_INIT_SYSTEMD
+	$(INSTALL) -m 0644 -D $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)/systemd/wpa_supplicant.service \
+		$(TARGET_DIR)/usr/lib/systemd/system/wpa_supplicant.service
+	$(INSTALL) -m 0644 -D $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)/systemd/wpa_supplicant@.service \
+		$(TARGET_DIR)/usr/lib/systemd/system/wpa_supplicant@.service
+	$(INSTALL) -m 0644 -D $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)/systemd/wpa_supplicant-nl80211@.service \
+		$(TARGET_DIR)/usr/lib/systemd/system/wpa_supplicant-nl80211@.service
+	$(INSTALL) -m 0644 -D $(@D)/$(WPA_SUPPLICANT_K44_SUBDIR)/systemd/wpa_supplicant-wired@.service \
+		$(TARGET_DIR)/usr/lib/systemd/system/wpa_supplicant-wired@.service
+	$(INSTALL) -D -m 644 $(WPA_SUPPLICANT_K44_PKGDIR)/50-wpa_supplicant.preset \
+		$(TARGET_DIR)/usr/lib/systemd/system-preset/50-wpa_supplicant.preset
+endef
+
+$(eval $(generic-package))

--- a/package/wpa_supplicant_k44/wpa_supplicant_k44.hash
+++ b/package/wpa_supplicant_k44/wpa_supplicant_k44.hash
@@ -1,0 +1,5 @@
+# Locally calculated
+sha256  fcbdee7b4a64bea8177973299c8c824419c413ec2e3a95db63dd6a5dc3541f17  wpa_supplicant-2.9.tar.gz
+sha256  9da5dd0776da266b180b915e460ff75c6ff729aca1196ab396529510f24f3761  README
+sha256  c4d65cc13863e0237d0644198558e2c47b4ed91e2b2be4516ff590724187c4a5  0001-P2P-Fix-copying-of-secondary-device-types-for-P2P-gr.patch
+sha256  7f40cfec5faf5e927ea9028ab9392cd118685bde7229ad24210caf0a8f6e9611  0001-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch


### PR DESCRIPTION
Looks like when updating buildroot to the stable 2023.11.2 base the WPA_SUPPLICANT_K44 package was removed.

Very likely this is the reason why wifi doesn't work on RK3326 (and RK3128) boards.

This PR re-adds WPA_SUPPLICANT_K44 package.