### PR TITLE
Sync wayland-protocols to buildroot/master for dependency fix and bump to 1.39

### DIFF
--- a/package/wayland-protocols/wayland-protocols.hash
+++ b/package/wayland-protocols/wayland-protocols.hash
@@ -1,4 +1,4 @@
-# From https://lists.freedesktop.org/archives/wayland-devel/2024-October/043851.html
-sha256  ff17292c05159d2b20ce6cacfe42d7e31a28198fa1429a769b03af7c38581dbe  wayland-protocols-1.38.tar.xz
-sha512  43fc36d35bedb245deed0e2de246f42d2bbfa6ecafa094f2a7fb103d6df8ae28f3cc200bc5aa24745b9131a28381883c24779da0a6d9ac954753bd5ebb1405db  wayland-protocols-1.38.tar.xz
+# From https://lists.freedesktop.org/archives/wayland-devel/2024-December/043920.html
+sha256  e1dcdcbbf08e2e0a8a02ee5d9a0be3a6aafc39a4b51fa7e0d2f1a16411cb72fa  wayland-protocols-1.39.tar.xz
+sha512  480a195ec0846400d93160e3d0a7ba12948ed841835ee4661f54b0101ae0027affd9c0f660a73244786fecd70e4f609830489a6b95e00d750cf2379734aacbe0  wayland-protocols-1.39.tar.xz
 sha256  f1a2b233e8a9a71c40f4aa885be08a0842ac85bb8588703c1dd7e6e6502e3124  COPYING

--- a/package/wayland-protocols/wayland-protocols.mk
+++ b/package/wayland-protocols/wayland-protocols.mk
@@ -4,13 +4,15 @@
 #
 ################################################################################
 
-WAYLAND_PROTOCOLS_VERSION = 1.38
+WAYLAND_PROTOCOLS_VERSION = 1.39
 WAYLAND_PROTOCOLS_SITE = https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/$(WAYLAND_PROTOCOLS_VERSION)/downloads
 WAYLAND_PROTOCOLS_SOURCE = wayland-protocols-$(WAYLAND_PROTOCOLS_VERSION).tar.xz
 WAYLAND_PROTOCOLS_LICENSE = MIT
 WAYLAND_PROTOCOLS_LICENSE_FILES = COPYING
 WAYLAND_PROTOCOLS_INSTALL_STAGING = YES
 WAYLAND_PROTOCOLS_INSTALL_TARGET = NO
+# needs wayland-scanner
+WAYLAND_PROTOCOLS_DEPENDENCIES = host-wayland
 
 WAYLAND_PROTOCOLS_CONF_OPTS = -Dtests=false
 


### PR DESCRIPTION
Sync wayland-protocols to buildroot/master for dependency fix and bump to 1.39