### PR TITLE
Add install-images dependency on install-target

### DIFF
--- a/package/pkg-generic.mk
+++ b/package/pkg-generic.mk
@@ -913,6 +913,9 @@ endif
 ifeq ($$($(2)_INSTALL_TARGET),YES)
 $(1)-install-target:		$$($(2)_TARGET_INSTALL_TARGET)
 $$($(2)_TARGET_INSTALL_TARGET):	$$($(2)_TARGET_BUILD)
+# batocera - fix intra-package dependency in boot/syslinux
+# Some packages use install-target stuff for install-images
+$$($(2)_TARGET_INSTALL_IMAGES):	$$($(2)_TARGET_INSTALL_TARGET)
 else
 $(1)-install-target:
 endif


### PR DESCRIPTION
In current buildroot, install-target has an intra-package dependency on install-staging to ensure that staging artifacts can be consumed when installing to target.

Because of the way the boot/syslinux package is constructed, it requires a similar dependency to ensure that target artifacts can be consumed when installing images.

Without this dependency, a race condition is apparent when running a parallel build, which can result in intermittent failures.

This patch should be upstreamed, if I can figure out how to do that.