### PR TITLE
Fix: Remove duplicate hwdata dependency.

### DIFF
--- a/package/wlroots/wlroots.mk
+++ b/package/wlroots/wlroots.mk
@@ -13,7 +13,6 @@ WLROOTS_INSTALL_STAGING = YES
 WLROOTS_DEPENDENCIES = \
 	host-pkgconf \
 	host-wayland \
-	hwdata \
 	libinput \
 	libxkbcommon \
 	libegl \
@@ -21,9 +20,9 @@ WLROOTS_DEPENDENCIES = \
 	pixman \
 	seatd \
 	udev \
-    hwdata \
-    libdisplay-info \
-    libliftoff \
+	hwdata \
+	libdisplay-info \
+	libliftoff \
 	wayland \
 	wayland-protocols
 


### PR DESCRIPTION
Remove the duplicate hwdata entry to ensure the dependency is only listed once.