### PR TITLE
yad to 0.42.0

### DIFF
--- a/package/yad/yad.hash
+++ b/package/yad/yad.hash
@@ -1,6 +1,5 @@
-# From http://sourceforge.net/projects/yad-dialog/files/
-md5  82d458a2e1695dd0709f71ad26109812  yad-0.40.0.tar.xz
-sha1  4376eb42f8e38972124dc81e534cbdc9088109fb  yad-0.40.0.tar.xz
+# Locally calculated
+sha256  f2d2e54d3ad4c27eda0f92623fab93059ae95a3dd52fd32b007d3a1adc2cad91  yad-v0.42.0.tar.gz
 
 # Hash for license file
 sha256  8ceb4b9ee5adedde47b31e975c1d90c73ad27b6b165a1dcd80c7c545eb65b903  COPYING

--- a/package/yad/yad.mk
+++ b/package/yad/yad.mk
@@ -4,14 +4,16 @@
 #
 ################################################################################
 
-YAD_VERSION = 0.40.0
-YAD_SOURCE = yad-$(YAD_VERSION).tar.xz
-YAD_SITE = http://sourceforge.net/projects/yad-dialog/files
+YAD_VERSION = v0.42.0
+YAD_SITE = $(call github,v1cont,yad,$(YAD_VERSION))
 YAD_LICENSE = GPL-3.0
 YAD_LICENSE_FILES = COPYING
 YAD_DEPENDENCIES = host-intltool host-pkgconf $(TARGET_NLS_DEPENDENCIES)
 YAD_CONF_ENV = LIBS=$(TARGET_NLS_LIBS)
 YAD_CONF_OPTS = --enable-html=no
+
+# batocera add autoreconf & opts
+YAD_AUTORECONF = YES
 
 ifeq ($(BR2_PACKAGE_LIBGTK3_X11),y)
 YAD_DEPENDENCIES += libgtk3


### PR DESCRIPTION
package/yad: bump to version 0.42.0

Since the yad SourceForge repository is no longer maintained, we switched to the author’s GitHub repository. For now, we’re not updating to the latest version, in case some parameters are incompatible.

The current version has been tested and works fine. The latest version, 14.2, has not been tested yet, and it may need to be upgraded together with the Wine toolbox scripts.