### PR TITLE
restore acpid.mk to the buildroot version.

### DIFF
--- a/package/acpid/acpid.mk
+++ b/package/acpid/acpid.mk
@@ -35,7 +35,6 @@ define ACPID_SET_EVENTS
 		>$(TARGET_DIR)/etc/acpi/events/powerbtn
 endef
 
-# batocera : we won't that
-#ACPID_POST_INSTALL_TARGET_HOOKS += ACPID_SET_EVENTS
+ACPID_POST_INSTALL_TARGET_HOOKS += ACPID_SET_EVENTS
 
 $(eval $(autotools-package))


### PR DESCRIPTION
In my x86_64 batocera v42 box, acpid fails during system startup.  Here is the log:
```
Feb  6 18:53:27 batocera acpid: starting up with netlink and the input layer
Feb  6 18:53:27 batocera acpid: opendir(/etc/acpi/events): No such file or directory
```
Acpid does not run in the background.

After I created “/etc/acpi/events” directory, acpid ran successfully. The log is:
```
Feb  6 18:54:05 batocera acpid: starting up with netlink and the input layer
Feb  6 18:54:05 batocera acpid: 0 rules loaded
Feb  6 18:54:05 batocera acpid: waiting for events: event logging is off
Feb  6 18:54:05 batocera acpid: client connected from 1934[0:0]
Feb  6 18:54:05 batocera acpid: 1 client rule loaded
```

Acpid needs “/etc/acpi/events” directory. If batocera wants to ignore the power button event, it would be better to comment out the lines which creates power button event handler.